### PR TITLE
[FEAT] 프로필 정보 입력 페이지 UI, 이미지 선택 기능 구현

### DIFF
--- a/WooHyepHa-iOS/Sources/App/Coordinator/Coordinator.swift
+++ b/WooHyepHa-iOS/Sources/App/Coordinator/Coordinator.swift
@@ -24,4 +24,8 @@ extension Coordinator {
             }
         }
     }
+    
+    func pop() {
+        navigationController.popViewController(animated: true)
+    }
 }

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterProfile/Components/BirthInputView.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterProfile/Components/BirthInputView.swift
@@ -21,7 +21,7 @@ class BirthInputView: BaseView {
         $0.textColor = .gray1
     }
     
-    private let birthTextField = UITextField().then {
+    private lazy var birthTextField = UITextField().then {
         $0.placeholder = "태어난 연도를 설정해 주세요!"
         $0.font = .body4
         $0.layer.borderColor = UIColor.gray7.cgColor
@@ -29,7 +29,18 @@ class BirthInputView: BaseView {
         $0.layer.cornerRadius = 10
         $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 20, height: 0))
         $0.leftViewMode = .always
+        $0.delegate = self
+        $0.tintColor = .clear
     }
+    
+    private lazy var yearPicker = UIPickerView().then {
+        $0.delegate = self
+        $0.dataSource = self
+        $0.backgroundColor = .white
+        $0.tintColor = .black
+    }
+    
+    private let years = Array(1930...2009).map { String($0) }
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -45,6 +56,8 @@ class BirthInputView: BaseView {
         [birthLabel, birthTextField].forEach {
             addSubview($0)
         }
+        
+        setupPicker()
     }
     
     override func setConstraints() {
@@ -59,10 +72,21 @@ class BirthInputView: BaseView {
             $0.horizontalEdges.equalToSuperview().inset(20)
             $0.height.equalTo(48)
         }
+
     }
     
     //MARK: Bind
     override func bind() {
+    }
+}
+
+private extension BirthInputView {
+    func setupPicker() {
+        birthTextField.inputView = yearPicker
+        
+        if let defaultYearIndex = years.firstIndex(of: "2000") {
+            yearPicker.selectRow(defaultYearIndex, inComponent: 0, animated: false)
+        }
     }
 }
 
@@ -72,5 +96,45 @@ extension BirthInputView {
 
 //MARK: Observable
 extension BirthInputView {
+    var isValidBirth: Observable<Bool> {
+        return birthTextField.rx.text.orEmpty.map { !$0.isEmpty }
+    }
 }
 
+extension BirthInputView: UIPickerViewDelegate {
+    func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
+        let label = UILabel()
+        label.text = years[row]
+        label.textAlignment = .center
+        label.font = .body2
+        return label
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, rowHeightForComponent component: Int) -> CGFloat {
+        return 32
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        birthTextField.text = years[row]
+    }
+}
+
+extension BirthInputView: UIPickerViewDataSource {
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 1
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        return years.count
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        return years[row]
+    }
+}
+
+extension BirthInputView: UITextFieldDelegate {
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        return false
+    }
+}

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterProfile/Components/NicknameInputView.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterProfile/Components/NicknameInputView.swift
@@ -103,6 +103,14 @@ extension NicknameInputView {
         nickNameTextField.rx.text.orEmpty
             .asObservable()
     }
+    
+    var isValidNickname: Observable<Bool> {
+        return Observable.combineLatest(
+            inputNickname,
+            nickNameTextField.rx.text.orEmpty.map { !$0.isEmpty }
+        )
+        .map { !$0.0.isEmpty }
+    }
 }
 
 extension NicknameInputView: UITextFieldDelegate {

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterProfile/Components/RegisterProfileFooterView.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterProfile/Components/RegisterProfileFooterView.swift
@@ -25,7 +25,7 @@ class RegisterProfileFooterView: BaseView {
         $0.setTitle("다음", for: .normal)
         $0.setTitleColor(.white, for: .normal)
         $0.titleLabel?.font = .body2
-        $0.backgroundColor = .gray1
+        $0.backgroundColor = .gray6
         $0.layer.cornerRadius = 10
     }
     
@@ -53,5 +53,21 @@ class RegisterProfileFooterView: BaseView {
             $0.horizontalEdges.equalToSuperview().inset(20)
             $0.height.equalTo(48)
         }
+    }
+    
+    override func bind() {
+        nextButton.rx.tap
+            .subscribe(with: self, onNext: { owner, _ in
+                owner.delegate?.nextButtonDidTap()
+            })
+            .disposed(by: disposeBag)
+    }
+}
+
+// MARK: View Method
+extension RegisterProfileFooterView {
+    func updateNextButtonState(isEnabled: Bool) {
+        nextButton.isEnabled = isEnabled
+        nextButton.backgroundColor = isEnabled ? .gray1 : .gray6
     }
 }

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterProfile/Components/SexInputView.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterProfile/Components/SexInputView.swift
@@ -128,5 +128,9 @@ extension SexInputView {
     var inputSelectedSex: Observable<String> {
         return selectedSex.asObservable()
     }
+    
+    var isValidSex: Observable<Bool> {
+        return selectedSex.map { !$0.isEmpty }
+    }
 }
 

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterProfile/RegisterProfileViewController.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterProfile/RegisterProfileViewController.swift
@@ -67,8 +67,9 @@ class RegisterProfileViewController: BaseViewController {
         $0.showBottomBorder = false
     }
     
-    private let footerView = RegisterProfileFooterView().then {
+    private lazy var footerView = RegisterProfileFooterView().then {
         $0.showBottomBorder = false
+        $0.delegate = self
     }
     
     override func viewDidLoad() {
@@ -168,11 +169,28 @@ private extension RegisterProfileViewController {
                 print("닉네임: \(nickname), 성별: \(sex)")
             })
             .disposed(by: disposeBag)
+        
+        Observable.combineLatest(
+            nicknameInputView.isValidNickname,
+            sexInputView.isValidSex,
+            birthInputView.isValidBirth
+        )
+        .map { $0 && $1 && $2 }
+        .bind(with: self) { owner, isValid in
+            owner.footerView.updateNextButtonState(isEnabled: isValid)
+        }
+        .disposed(by: disposeBag)
     }
 }
 
 extension RegisterProfileViewController: RegisterProfileHeaderViewDelegate {
     func backButtonDidTap() {
+        print("test Log: Button Tapped")
+    }
+}
+
+extension RegisterProfileViewController: RegisterProfileFooterViewDelegate {
+    func nextButtonDidTap() {
         print("test Log: Button Tapped")
     }
 }

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterProfile/RegisterProfileViewController.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterProfile/RegisterProfileViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import PhotosUI
 
 import RxCocoa
 import RxSwift
@@ -37,7 +38,7 @@ class RegisterProfileViewController: BaseViewController {
     private let addProfileImageButton = UIButton().then {
         $0.setImage(UIImage(named: "tabbar_mypage_active"), for: .normal)
         $0.backgroundColor = .gray7
-        
+        $0.imageView?.contentMode = .scaleAspectFill
         $0.layer.borderWidth = 3.5
         $0.layer.borderColor = UIColor.gray9.cgColor
         $0.layer.cornerRadius = 66
@@ -180,12 +181,61 @@ private extension RegisterProfileViewController {
             owner.footerView.updateNextButtonState(isEnabled: isValid)
         }
         .disposed(by: disposeBag)
+        
+        addProfileImageButton.rx.tap
+            .subscribe(with: self, onNext: { owner, _ in
+                owner.presentImagePicker()
+            })
+            .disposed(by: disposeBag)
+        
+        addProfileImageSubButton.rx.tap
+            .subscribe(with: self, onNext: { owner, _ in
+                owner.presentImagePicker()
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    func presentImagePicker() {
+        var configuration = PHPickerConfiguration()
+        configuration.filter = .images
+        configuration.selectionLimit = 1
+        
+        let picker = PHPickerViewController(configuration: configuration)
+        picker.delegate = self
+        present(picker, animated: true, completion: nil)
     }
 }
 
+extension RegisterProfileViewController: PHPickerViewControllerDelegate {
+    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        picker.dismiss(animated: true, completion: nil)
+        
+        guard let result = results.first else { return }
+        
+        result.itemProvider.loadObject(ofClass: UIImage.self) { [weak self] (object, error) in
+            if let error = error {
+                print("Error loading image: \(error.localizedDescription)")
+                return
+            }
+            
+            result.itemProvider.loadFileRepresentation(forTypeIdentifier: UTType.image.identifier) { [weak self] (url, error) in
+                if let error = error {
+                    print("Error loading image URL: \(error.localizedDescription)")
+                    return
+                }
+                
+                guard let image = object as? UIImage else { return }
+                
+                DispatchQueue.main.async {
+                    self?.addProfileImageButton.setImage(image, for: .normal)
+                }
+            }
+        }
+    }
+}
 extension RegisterProfileViewController: RegisterProfileHeaderViewDelegate {
     func backButtonDidTap() {
-        print("test Log: Button Tapped")
+        coordinator?.pop()
     }
 }
 


### PR DESCRIPTION
## 작업 내용
**1. 이미지 선택 기능을 구현하였습니다.**
![Aug-19-2024 15-35-19](https://github.com/user-attachments/assets/f3d264fd-fc46-4889-bdd1-0d89c7a7fb13)
➡️ PHPickerViewController를 사용하여 구현하였습니다.

**2. 유효성 검사에 따른 다음 버튼의 상태 변화를 구현하였습니다.**
![Aug-19-2024 15-29-15](https://github.com/user-attachments/assets/532e2f63-2466-402f-83d1-a4c4a372cb9e)
➡️ 비즈니스 로직 미구현 상태이기 때문에 테스트 코드만 작성함. 나중에 로직 수정 예정입니다. 
프로필 등록 뷰컨에 모든 View를 구현하는 것보다 세부적으로 나누어 View를 모듈화하여 구현하였습니다. 따라서, 각 뷰마다 유효성 검사를 위한 Observable를 만들어, 상위 뷰컨에서 처리하도록 구현하였습니다.

**3. 코디네이터에 pop 메소드를 구현하였습니다.**
➡️ 필요한 코디네이터에서 pop을 여러번 구현하는 것보다, 최상위 코디네이터에서 구현하여 재사용하는 것이 좋다고 판단 되어 coordinator 클래스에 pop 메소드를 구현하였습니다.

## 관련 이슈
#12 - [FEAT] 프로필 등록(Register) 구현
