### PR TITLE
[FEAT] 취향 선택1 페이지 UI 구현

### DIFF
--- a/WooHyepHa-iOS.xcodeproj/project.pbxproj
+++ b/WooHyepHa-iOS.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		9E88DE2A2C7437CA00815EE0 /* RegisterPreferenceCultrueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE292C7437CA00815EE0 /* RegisterPreferenceCultrueViewController.swift */; };
 		9E88DE2D2C7439AE00815EE0 /* PreferenceCultureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE2C2C7439AE00815EE0 /* PreferenceCultureView.swift */; };
 		9E88DE312C74475500815EE0 /* PreferenceCultureButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE302C74475500815EE0 /* PreferenceCultureButton.swift */; };
+		9E88DE332C7466E100815EE0 /* OnboardingProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE322C7466E100815EE0 /* OnboardingProgressView.swift */; };
 		9E9C31032C6C739800F8B01A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9E9C30FF2C6C739800F8B01A /* LaunchScreen.storyboard */; };
 		9E9C31042C6C739800F8B01A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9E9C31012C6C739800F8B01A /* Main.storyboard */; };
 /* End PBXBuildFile section */
@@ -101,6 +102,7 @@
 		9E88DE292C7437CA00815EE0 /* RegisterPreferenceCultrueViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPreferenceCultrueViewController.swift; sourceTree = "<group>"; };
 		9E88DE2C2C7439AE00815EE0 /* PreferenceCultureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceCultureView.swift; sourceTree = "<group>"; };
 		9E88DE302C74475500815EE0 /* PreferenceCultureButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceCultureButton.swift; sourceTree = "<group>"; };
+		9E88DE322C7466E100815EE0 /* OnboardingProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingProgressView.swift; sourceTree = "<group>"; };
 		9E9C31002C6C739800F8B01A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		9E9C31022C6C739800F8B01A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Main.storyboard; sourceTree = "<group>"; };
 		9E9C310F2C6C77AC00F8B01A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -409,6 +411,7 @@
 			children = (
 				9E88DE222C74263100815EE0 /* OnboardingHeaderView.swift */,
 				9E88DE262C74340500815EE0 /* OnboardingFooterView.swift */,
+				9E88DE322C7466E100815EE0 /* OnboardingProgressView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -568,6 +571,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9E88DE332C7466E100815EE0 /* OnboardingProgressView.swift in Sources */,
 				9E88DE2D2C7439AE00815EE0 /* PreferenceCultureView.swift in Sources */,
 				9E0FF2B42C6B0C3500544674 /* MyPageViewController.swift in Sources */,
 				9E5906692C4F993C00647DEE /* ViewController.swift in Sources */,

--- a/WooHyepHa-iOS.xcodeproj/project.pbxproj
+++ b/WooHyepHa-iOS.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		9E88DE132C73243600815EE0 /* RegisterLocationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE122C73243600815EE0 /* RegisterLocationViewController.swift */; };
 		9E88DE232C74263100815EE0 /* OnboardingHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE222C74263100815EE0 /* OnboardingHeaderView.swift */; };
 		9E88DE272C74340500815EE0 /* OnboardingFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE262C74340500815EE0 /* OnboardingFooterView.swift */; };
+		9E88DE2A2C7437CA00815EE0 /* RegisterPreferenceCultrueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE292C7437CA00815EE0 /* RegisterPreferenceCultrueViewController.swift */; };
 		9E9C31032C6C739800F8B01A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9E9C30FF2C6C739800F8B01A /* LaunchScreen.storyboard */; };
 		9E9C31042C6C739800F8B01A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9E9C31012C6C739800F8B01A /* Main.storyboard */; };
 /* End PBXBuildFile section */
@@ -95,6 +96,7 @@
 		9E88DE122C73243600815EE0 /* RegisterLocationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterLocationViewController.swift; sourceTree = "<group>"; };
 		9E88DE222C74263100815EE0 /* OnboardingHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingHeaderView.swift; sourceTree = "<group>"; };
 		9E88DE262C74340500815EE0 /* OnboardingFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFooterView.swift; sourceTree = "<group>"; };
+		9E88DE292C7437CA00815EE0 /* RegisterPreferenceCultrueViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPreferenceCultrueViewController.swift; sourceTree = "<group>"; };
 		9E9C31002C6C739800F8B01A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		9E9C31022C6C739800F8B01A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Main.storyboard; sourceTree = "<group>"; };
 		9E9C310F2C6C77AC00F8B01A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -315,6 +317,7 @@
 				9E88DDF22C6DAFA900815EE0 /* Register */,
 				9E88DDF32C6DB24200815EE0 /* RegisterProfile */,
 				9E88DE112C73240D00815EE0 /* RegisterLocation */,
+				9E88DE282C74376000815EE0 /* RegisterPreferenceCulture */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -404,6 +407,14 @@
 				9E88DE262C74340500815EE0 /* OnboardingFooterView.swift */,
 			);
 			path = Components;
+			sourceTree = "<group>";
+		};
+		9E88DE282C74376000815EE0 /* RegisterPreferenceCulture */ = {
+			isa = PBXGroup;
+			children = (
+				9E88DE292C7437CA00815EE0 /* RegisterPreferenceCultrueViewController.swift */,
+			);
+			path = RegisterPreferenceCulture;
 			sourceTree = "<group>";
 		};
 		9E9C30FE2C6C739800F8B01A /* Base.lproj */ = {
@@ -568,6 +579,7 @@
 				9E0FF1F72C5A28C500544674 /* BaseViewController.swift in Sources */,
 				9E0FF29B2C6B095600544674 /* Coordinator.swift in Sources */,
 				9E0FF2A42C6B0A2B00544674 /* HomeCoordinator.swift in Sources */,
+				9E88DE2A2C7437CA00815EE0 /* RegisterPreferenceCultrueViewController.swift in Sources */,
 				9E88DDF92C6DB33D00815EE0 /* RegisterViewController.swift in Sources */,
 				9E0FF2B62C6B0C5100544674 /* MyPageCoordinator.swift in Sources */,
 				9E0FF2AC2C6B0B2800544674 /* MapViewController.swift in Sources */,

--- a/WooHyepHa-iOS.xcodeproj/project.pbxproj
+++ b/WooHyepHa-iOS.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		9E88DE272C74340500815EE0 /* OnboardingFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE262C74340500815EE0 /* OnboardingFooterView.swift */; };
 		9E88DE2A2C7437CA00815EE0 /* RegisterPreferenceCultrueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE292C7437CA00815EE0 /* RegisterPreferenceCultrueViewController.swift */; };
 		9E88DE2D2C7439AE00815EE0 /* PreferenceCultureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE2C2C7439AE00815EE0 /* PreferenceCultureView.swift */; };
+		9E88DE312C74475500815EE0 /* PreferenceCultureButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE302C74475500815EE0 /* PreferenceCultureButton.swift */; };
 		9E9C31032C6C739800F8B01A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9E9C30FF2C6C739800F8B01A /* LaunchScreen.storyboard */; };
 		9E9C31042C6C739800F8B01A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9E9C31012C6C739800F8B01A /* Main.storyboard */; };
 /* End PBXBuildFile section */
@@ -99,6 +100,7 @@
 		9E88DE262C74340500815EE0 /* OnboardingFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFooterView.swift; sourceTree = "<group>"; };
 		9E88DE292C7437CA00815EE0 /* RegisterPreferenceCultrueViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPreferenceCultrueViewController.swift; sourceTree = "<group>"; };
 		9E88DE2C2C7439AE00815EE0 /* PreferenceCultureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceCultureView.swift; sourceTree = "<group>"; };
+		9E88DE302C74475500815EE0 /* PreferenceCultureButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceCultureButton.swift; sourceTree = "<group>"; };
 		9E9C31002C6C739800F8B01A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		9E9C31022C6C739800F8B01A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Main.storyboard; sourceTree = "<group>"; };
 		9E9C310F2C6C77AC00F8B01A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -424,6 +426,7 @@
 			isa = PBXGroup;
 			children = (
 				9E88DE2C2C7439AE00815EE0 /* PreferenceCultureView.swift */,
+				9E88DE302C74475500815EE0 /* PreferenceCultureButton.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -586,6 +589,7 @@
 				9E0FF2B92C6C4F5A00544674 /* SplashViewController.swift in Sources */,
 				9E88DE0A2C6DD58B00815EE0 /* BirthInputView.swift in Sources */,
 				9E0FF2962C6B066200544674 /* TabBarItemType.swift in Sources */,
+				9E88DE312C74475500815EE0 /* PreferenceCultureButton.swift in Sources */,
 				9E88DE072C6DC85600815EE0 /* BaseView.swift in Sources */,
 				9E0FF2B02C6B0B8500544674 /* ChatViewController.swift in Sources */,
 				9E0FF1F72C5A28C500544674 /* BaseViewController.swift in Sources */,

--- a/WooHyepHa-iOS.xcodeproj/project.pbxproj
+++ b/WooHyepHa-iOS.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		9E88DE232C74263100815EE0 /* OnboardingHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE222C74263100815EE0 /* OnboardingHeaderView.swift */; };
 		9E88DE272C74340500815EE0 /* OnboardingFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE262C74340500815EE0 /* OnboardingFooterView.swift */; };
 		9E88DE2A2C7437CA00815EE0 /* RegisterPreferenceCultrueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE292C7437CA00815EE0 /* RegisterPreferenceCultrueViewController.swift */; };
+		9E88DE2D2C7439AE00815EE0 /* PreferenceCultureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE2C2C7439AE00815EE0 /* PreferenceCultureView.swift */; };
 		9E9C31032C6C739800F8B01A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9E9C30FF2C6C739800F8B01A /* LaunchScreen.storyboard */; };
 		9E9C31042C6C739800F8B01A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9E9C31012C6C739800F8B01A /* Main.storyboard */; };
 /* End PBXBuildFile section */
@@ -97,6 +98,7 @@
 		9E88DE222C74263100815EE0 /* OnboardingHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingHeaderView.swift; sourceTree = "<group>"; };
 		9E88DE262C74340500815EE0 /* OnboardingFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFooterView.swift; sourceTree = "<group>"; };
 		9E88DE292C7437CA00815EE0 /* RegisterPreferenceCultrueViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPreferenceCultrueViewController.swift; sourceTree = "<group>"; };
+		9E88DE2C2C7439AE00815EE0 /* PreferenceCultureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceCultureView.swift; sourceTree = "<group>"; };
 		9E9C31002C6C739800F8B01A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		9E9C31022C6C739800F8B01A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Main.storyboard; sourceTree = "<group>"; };
 		9E9C310F2C6C77AC00F8B01A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -412,9 +414,18 @@
 		9E88DE282C74376000815EE0 /* RegisterPreferenceCulture */ = {
 			isa = PBXGroup;
 			children = (
+				9E88DE2B2C74399500815EE0 /* Components */,
 				9E88DE292C7437CA00815EE0 /* RegisterPreferenceCultrueViewController.swift */,
 			);
 			path = RegisterPreferenceCulture;
+			sourceTree = "<group>";
+		};
+		9E88DE2B2C74399500815EE0 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				9E88DE2C2C7439AE00815EE0 /* PreferenceCultureView.swift */,
+			);
+			path = Components;
 			sourceTree = "<group>";
 		};
 		9E9C30FE2C6C739800F8B01A /* Base.lproj */ = {
@@ -554,6 +565,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9E88DE2D2C7439AE00815EE0 /* PreferenceCultureView.swift in Sources */,
 				9E0FF2B42C6B0C3500544674 /* MyPageViewController.swift in Sources */,
 				9E5906692C4F993C00647DEE /* ViewController.swift in Sources */,
 				9E0FF2AE2C6B0B4F00544674 /* MapCoordinator.swift in Sources */,

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/Components/OnboardingProgressView.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/Components/OnboardingProgressView.swift
@@ -1,0 +1,20 @@
+//
+//  OnboardingProgressView.swift
+//  WooHyepHa-iOS
+//
+//  Created by 여성일 on 8/20/24.
+//
+
+import UIKit
+
+class OnboardingProgressView: UIProgressView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/Components/OnboardingProgressView.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/Components/OnboardingProgressView.swift
@@ -7,14 +7,33 @@
 
 import UIKit
 
+import SnapKit
+import Then
+
 class OnboardingProgressView: UIProgressView {
 
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
+    private var progressValue: Float
+    
+    // MARK: init
+    init(progressValue: Float) {
+        self.progressValue = progressValue
+        super.init(frame: .zero)
+        setProgressView()
     }
-    */
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
 
+private extension OnboardingProgressView {
+    func setProgressView() {
+        trackTintColor = .gray8
+        progressTintColor = .MainColor
+        clipsToBounds = true
+        layer.cornerRadius = 3
+        subviews[1].clipsToBounds = true
+        layer.sublayers![1].cornerRadius = 3
+        progress = progressValue
+    }
 }

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/Coordinator/OnboardingCoordinator.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/Coordinator/OnboardingCoordinator.swift
@@ -54,5 +54,11 @@ extension OnboardingCoordinator {
         let registerLocationViewController = RegisterLocationViewController()
         registerLocationViewController.coordinator = self
         navigationController.pushViewController(registerLocationViewController, animated: true)
+    }    
+    
+    func goToRegisterPreferencCultureViewController() {
+        let registerPreferencCultureViewController = RegisterPreferenceCultrueViewController()
+        registerPreferencCultureViewController.coordinator = self
+        navigationController.pushViewController(registerPreferencCultureViewController, animated: true)
     }
 }

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterLocation/RegisterLocationViewController.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterLocation/RegisterLocationViewController.swift
@@ -71,6 +71,7 @@ class RegisterLocationViewController: BaseViewController {
     private lazy var footerView = OnboardingFooterView().then {
         $0.showBottomBorder = false
         $0.delegate = self
+        $0.updateNextButtonState(isEnabled: true)
     }
     
     override func viewDidLoad() {
@@ -137,6 +138,7 @@ extension RegisterLocationViewController: OnboardingHeaderViewDelegate {
 extension RegisterLocationViewController: OnboardingFooterViewDelegate {
     func nextButtonDidTap() {
         print("testLog: nextButton Tapped")
+        coordinator?.goToRegisterPreferencCultureViewController()
     }
 }
 

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceCulture/Components/PreferenceCultureButton.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceCulture/Components/PreferenceCultureButton.swift
@@ -51,7 +51,7 @@ private extension PreferenceCultureButton {
         if isSelected {
             backgroundColor = .MainColor.withAlphaComponent(0.1)
             layer.borderColor = UIColor.MainColor.cgColor
-            layer.borderWidth = 1
+            layer.borderWidth = 2
             buttonTitleLabel.textColor = .MainColor
         } else {
             backgroundColor = .gray9

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceCulture/Components/PreferenceCultureButton.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceCulture/Components/PreferenceCultureButton.swift
@@ -1,0 +1,20 @@
+//
+//  PreferenceCultureButton.swift
+//  WooHyepHa-iOS
+//
+//  Created by 여성일 on 8/20/24.
+//
+
+import UIKit
+
+class PreferenceCultureButton: UIButton {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceCulture/Components/PreferenceCultureButton.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceCulture/Components/PreferenceCultureButton.swift
@@ -1,20 +1,63 @@
-//
-//  PreferenceCultureButton.swift
-//  WooHyepHa-iOS
-//
-//  Created by 여성일 on 8/20/24.
-//
-
 import UIKit
 
 class PreferenceCultureButton: UIButton {
-
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
+    
+    private var title: String
+    private let buttonTitleLabel = UILabel()
+    
+    override var isSelected: Bool {
+        didSet {
+            updateAppearance()
+        }
     }
-    */
+    
+    init(title: String) {
+        self.title = title
+        super.init(frame: .zero)
+        setButton()
+        setupTitleLabel()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        positionTitleLabel()
+    }
+}
 
+private extension PreferenceCultureButton {
+    func setButton() {
+        layer.cornerRadius = 10
+        layer.borderWidth = 0
+        updateAppearance()
+    }
+    
+    func setupTitleLabel() {
+        buttonTitleLabel.text = title
+        buttonTitleLabel.textColor = .gray1
+        buttonTitleLabel.font = .body1
+        buttonTitleLabel.textAlignment = .center
+        addSubview(buttonTitleLabel)
+    }
+    
+    func positionTitleLabel() {
+        buttonTitleLabel.frame = CGRect(x: 0, y: bounds.height - 30, width: bounds.width, height: 20)
+    }
+    
+    func updateAppearance() {
+        if isSelected {
+            backgroundColor = .MainColor.withAlphaComponent(0.1)
+            layer.borderColor = UIColor.MainColor.cgColor
+            layer.borderWidth = 1
+            buttonTitleLabel.textColor = .MainColor
+        } else {
+            backgroundColor = .gray9
+            layer.borderColor = UIColor.gray9.cgColor
+            layer.borderWidth = 0
+            buttonTitleLabel.textColor = .gray1
+        }
+    }
 }

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceCulture/Components/PreferenceCultureView.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceCulture/Components/PreferenceCultureView.swift
@@ -1,0 +1,29 @@
+//
+//  PreferenceCultureView.swift
+//  WooHyepHa-iOS
+//
+//  Created by 여성일 on 8/20/24.
+//
+
+import UIKit
+
+class PreferenceCultureView: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceCulture/Components/PreferenceCultureView.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceCulture/Components/PreferenceCultureView.swift
@@ -1,29 +1,120 @@
-//
-//  PreferenceCultureView.swift
-//  WooHyepHa-iOS
-//
-//  Created by 여성일 on 8/20/24.
-//
-
 import UIKit
 
-class PreferenceCultureView: UIViewController {
+import Then
+import SnapKit
+import RxCocoa
+import RxSwift
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
+class PreferenceCultureView: BaseView {
 
-        // Do any additional setup after loading the view.
+    private let exhibitionButton = PreferenceCultureButton(title: "전시회")
+    private let concertButton = PreferenceCultureButton(title: "콘서트")
+    private let musicalButton = PreferenceCultureButton(title: "뮤지컬/연극")
+    private let filmFestivalButton = PreferenceCultureButton(title: "영화제")
+    
+    private let horizontalStackView1 = UIStackView().then {
+        $0.axis = .horizontal
+        $0.distribution = .fillEqually
+        $0.spacing = 10
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    private let horizontalStackView2 = UIStackView().then {
+        $0.axis = .horizontal
+        $0.distribution = .fillEqually
+        $0.spacing = 10
     }
-    */
+    
+    private let verticalStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.distribution = .fillEqually
+        $0.spacing = 10
+    }
 
+    private var selectedCultures: Set<String> = []
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func setView() {
+        showTopBorder = false
+        showBottomBorder = false
+        
+        [exhibitionButton, concertButton].forEach {
+            horizontalStackView1.addArrangedSubview($0)
+        }
+        
+        [musicalButton, filmFestivalButton].forEach {
+            horizontalStackView2.addArrangedSubview($0)
+        }
+        
+        [horizontalStackView1, horizontalStackView2].forEach {
+            verticalStackView.addArrangedSubview($0)
+        }
+        addSubview(verticalStackView)
+    }
+    
+    override func setConstraints() {
+        verticalStackView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.width.equalToSuperview().multipliedBy(0.8)
+            $0.height.equalTo(verticalStackView.snp.width)
+        }
+    }
+    
+    override func bind() {
+        inputPreferenceCulture
+            .subscribe(with: self, onNext: { owner, type in
+                owner.toggleButton(type)
+            })
+            .disposed(by: disposeBag)
+    }
+}
+
+extension PreferenceCultureView {
+    enum PreferenceCultureButtonType: String {
+        case exhibition = "exhibition"
+        case concert = "concert"
+        case musical = "musical"
+        case filmFestival = "filmFestival"
+    }
+    
+    var inputPreferenceCulture: Observable<String> {
+        return Observable.merge(
+            exhibitionButton.rx.tap.map { PreferenceCultureButtonType.exhibition.rawValue },
+            concertButton.rx.tap.map { PreferenceCultureButtonType.concert.rawValue },
+            musicalButton.rx.tap.map { PreferenceCultureButtonType.musical.rawValue },
+            filmFestivalButton.rx.tap.map { PreferenceCultureButtonType.filmFestival.rawValue }
+        )
+    }
+}
+
+extension PreferenceCultureView {
+    private func toggleButton(_ field: String) {
+        if let buttonType = PreferenceCultureButtonType(rawValue: field) {
+            let button: PreferenceCultureButton
+            switch buttonType {
+            case .exhibition:
+                button = exhibitionButton
+            case .concert:
+                button = concertButton
+            case .musical:
+                button = musicalButton
+            case .filmFestival:
+                button = filmFestivalButton
+            }
+            
+            button.isSelected.toggle()
+            
+            if button.isSelected {
+                selectedCultures.insert(field)
+            } else {
+                selectedCultures.remove(field)
+            }
+        }
+    }
 }

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceCulture/Components/PreferenceCultureView.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceCulture/Components/PreferenceCultureView.swift
@@ -61,7 +61,7 @@ class PreferenceCultureView: BaseView {
     override func setConstraints() {
         verticalStackView.snp.makeConstraints {
             $0.center.equalToSuperview()
-            $0.width.equalToSuperview().multipliedBy(0.8)
+            $0.width.equalToSuperview()
             $0.height.equalTo(verticalStackView.snp.width)
         }
     }

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceCulture/RegisterPreferenceCultrueViewController.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceCulture/RegisterPreferenceCultrueViewController.swift
@@ -24,7 +24,16 @@ class RegisterPreferenceCultrueViewController: BaseViewController {
         $0.rightButtonTitleColor = .gray4
     }
 
+    private let progressView = OnboardingProgressView(progressValue: 0.1667)
+    
     private lazy var preferenceCultureView = PreferenceCultureView()
+    
+    private let subTitle = UILabel().then {
+        $0.text = "나중에 다시 수정할 수 있어요!"
+        $0.textAlignment = .center
+        $0.textColor = .gray4
+        $0.font = .body4
+    }
     
     private lazy var footerView = OnboardingFooterView().then {
         $0.showBottomBorder = false
@@ -40,7 +49,7 @@ class RegisterPreferenceCultrueViewController: BaseViewController {
     override func setViewController() {
         view.backgroundColor = .white
         
-        [headerView, preferenceCultureView, footerView].forEach {
+        [headerView, progressView, preferenceCultureView, subTitle, footerView].forEach {
             view.addSubview($0)
         }
     }
@@ -52,10 +61,21 @@ class RegisterPreferenceCultrueViewController: BaseViewController {
             $0.height.equalTo(56)
         }
         
-        preferenceCultureView.snp.makeConstraints {
-            $0.top.equalTo(headerView).offset(80)
+        progressView.snp.makeConstraints {
+            $0.top.equalTo(headerView.snp.bottom).offset(10)
+            $0.height.equalTo(6)
             $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(20)
-            $0.bottom.equalTo(footerView.snp.top).inset(80)
+        }
+        
+        preferenceCultureView.snp.makeConstraints {
+            $0.top.equalTo(progressView.snp.bottom).offset(15)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(20)
+            $0.bottom.equalTo(subTitle.snp.top).offset(-15)
+        }
+        
+        subTitle.snp.makeConstraints {
+            $0.bottom.equalTo(footerView.snp.top).offset(-18)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(20)
         }
         
         footerView.snp.makeConstraints {

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceCulture/RegisterPreferenceCultrueViewController.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceCulture/RegisterPreferenceCultrueViewController.swift
@@ -7,23 +7,84 @@
 
 import UIKit
 
-class RegisterPreferenceCultrueViewController: UIViewController {
+import RxCocoa
+import RxSwift
+import SnapKit
+import Then
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
+class RegisterPreferenceCultrueViewController: BaseViewController {
 
-        // Do any additional setup after loading the view.
+    weak var coordinator: OnboardingCoordinator?
+
+    //MARK: UI Components
+    private lazy var headerView = OnboardingHeaderView().then {
+        $0.delegate = self
+        $0.backgroundColor = .white
+        $0.rightButtonTitle = "건너뛰기"
+        $0.rightButtonTitleColor = .gray4
+    }
+
+    private lazy var preferenceCultureView = PreferenceCultureView()
+    
+    private lazy var footerView = OnboardingFooterView().then {
+        $0.showBottomBorder = false
+        $0.delegate = self
+        $0.updateNextButtonState(isEnabled: true)
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    override func viewDidLoad() {
+        super.viewDidLoad()
     }
-    */
+    
+    // MARK: Set ViewController
+    override func setViewController() {
+        view.backgroundColor = .white
+        
+        [headerView, preferenceCultureView, footerView].forEach {
+            view.addSubview($0)
+        }
+    }
+    
+    override func setConstraints() {
+        headerView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide)
+            $0.height.equalTo(56)
+        }
+        
+        preferenceCultureView.snp.makeConstraints {
+            $0.top.equalTo(headerView).offset(80)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(20)
+            $0.bottom.equalTo(footerView.snp.top).inset(80)
+        }
+        
+        footerView.snp.makeConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide)
+            $0.height.equalTo(75)
+        }
+    }
+    
+    override func bind() {
+        preferenceCultureView.inputPreferenceCulture
+            .subscribe(with: self, onNext: { owner, type in
+            })
+            .disposed(by: disposeBag)
+    }
+}
 
+extension RegisterPreferenceCultrueViewController: OnboardingHeaderViewDelegate {
+    func leftButtonDidTap() {
+        coordinator?.pop()
+    }
+    
+    func rightButtonDidTap() {
+        print("testLog: rightButton Tapped")
+    }
+}
+
+extension RegisterPreferenceCultrueViewController: OnboardingFooterViewDelegate {
+    func nextButtonDidTap() {
+        print("testLog: nextButton Tapped")
+    }
 }

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceCulture/RegisterPreferenceCultrueViewController.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceCulture/RegisterPreferenceCultrueViewController.swift
@@ -1,0 +1,29 @@
+//
+//  RegisterPreferenceCultrueViewController.swift
+//  WooHyepHa-iOS
+//
+//  Created by 여성일 on 8/20/24.
+//
+
+import UIKit
+
+class RegisterPreferenceCultrueViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceCulture/RegisterPreferenceCultrueViewController.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceCulture/RegisterPreferenceCultrueViewController.swift
@@ -70,6 +70,20 @@ class RegisterPreferenceCultrueViewController: BaseViewController {
             .subscribe(with: self, onNext: { owner, type in
             })
             .disposed(by: disposeBag)
+        
+        var selected: [String] = []
+        
+        preferenceCultureView.inputPreferenceCulture
+            .subscribe(with: self, onNext: { owner, type in
+                if let index = selected.firstIndex(of: type) {
+                    selected.remove(at: index)
+                } else {
+                    selected.append(type)
+                }
+                
+                print(selected)
+            })
+            .disposed(by: disposeBag)
     }
 }
 

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterProfile/Components/SexInputView.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterProfile/Components/SexInputView.swift
@@ -24,37 +24,23 @@ class SexInputView: BaseView {
     }
     
     private let maleButton = UIButton().then {
+        $0.setTitle("남성", for: .normal)
+        $0.setTitleColor(.gray4, for: .normal)
+        $0.titleLabel?.font = .body4
+        $0.backgroundColor = .white
         $0.layer.borderWidth = 1
         $0.layer.borderColor = UIColor.gray7.cgColor
         $0.layer.cornerRadius = 5
-        
-        var configuration = UIButton.Configuration.filled()
-        configuration.baseBackgroundColor = UIColor.white
-        
-        var titleContainer = AttributeContainer()
-        titleContainer.font = UIFont.body4
-        titleContainer.foregroundColor = UIColor.gray4
-        configuration.attributedTitle = AttributedString("남성", attributes: titleContainer)
-        
-        $0.configuration = configuration
-        $0.changesSelectionAsPrimaryAction = true
     }
     
     private let femaleButton = UIButton().then {
+        $0.setTitle("여성", for: .normal)
+        $0.setTitleColor(.gray4, for: .normal)
+        $0.titleLabel?.font = .body4
+        $0.backgroundColor = .white
         $0.layer.borderWidth = 1
         $0.layer.borderColor = UIColor.gray7.cgColor
         $0.layer.cornerRadius = 5
-        
-        var configuration = UIButton.Configuration.filled()
-        configuration.baseBackgroundColor = UIColor.white
-        
-        var titleContainer = AttributeContainer()
-        titleContainer.font = UIFont.body4
-        titleContainer.foregroundColor = UIColor.gray4
-        configuration.attributedTitle = AttributedString("여성", attributes: titleContainer)
-        
-        $0.configuration = configuration
-        $0.changesSelectionAsPrimaryAction = true
     }
     
     override init(frame: CGRect) {
@@ -70,30 +56,6 @@ class SexInputView: BaseView {
         
         [sexLabel, maleButton, femaleButton].forEach {
             addSubview($0)
-        }
-        
-        [maleButton, femaleButton].forEach {
-            $0.configurationUpdateHandler = { button in
-                let textColor: UIColor = button.state == .selected ? UIColor.MainColor : UIColor.gray4
-                let backgroundColor: UIColor = button.state == .selected ? UIColor.MainColor.withAlphaComponent(0.1) : UIColor.white
-                let borderColor: CGColor = button.state == .selected ? UIColor.MainColor.cgColor : UIColor.gray7.cgColor
-                
-                button.layer.borderColor = borderColor
-                
-                let attributesTransformer = UIConfigurationTextAttributesTransformer { attributes in
-                    var updatedAttributes = attributes
-                    updatedAttributes.foregroundColor = textColor
-                    return updatedAttributes
-                }
-                
-                var updatedConfiguration = button.configuration
-                
-                updatedConfiguration?.baseBackgroundColor = backgroundColor
-                updatedConfiguration?.titleTextAttributesTransformer = attributesTransformer
-                
-                button.configuration?.baseBackgroundColor = backgroundColor
-                button.configuration = updatedConfiguration
-            }
         }
     }
     
@@ -121,39 +83,53 @@ class SexInputView: BaseView {
     
     //MARK: Bind
     override func bind() {
+        inputSelectedSex
+            .subscribe(with: self) { owner, type in
+                owner.updateButtonState(selected: type)
+            }
+            .disposed(by: disposeBag)
     }
 }
 
 // MARK: View Method
 extension SexInputView {
-    func updateButton(field: String) {
-        let allButtons = [maleButton, femaleButton]
-        allButtons.forEach { $0.isSelected = false }
+    private func updateButtonState(selected: String) {
         
-        if let buttonType = SexType(rawValue: field) {
+        if let buttonType = SexButtonType(rawValue: selected) {
             switch buttonType {
             case .male:
-                maleButton.isSelected = true
+                maleButton.layer.borderColor = UIColor.MainColor.cgColor
+                maleButton.setTitleColor(.MainColor, for: .normal)
+                maleButton.backgroundColor = .MainColor.withAlphaComponent(0.1)
+                femaleButton.layer.borderColor = UIColor.gray7.cgColor
+                femaleButton.setTitleColor(.gray4, for: .normal)
+                femaleButton.backgroundColor = .white
                 selectedSex.onNext("male")
             case .female:
-                femaleButton.isSelected = true
+                maleButton.layer.borderColor = UIColor.gray7.cgColor
+                maleButton.setTitleColor(.gray4, for: .normal)
+                maleButton.backgroundColor = .white
+                femaleButton.layer.borderColor = UIColor.MainColor.cgColor
+                femaleButton.setTitleColor(.MainColor, for: .normal)
+                femaleButton.backgroundColor = .MainColor.withAlphaComponent(0.1)
                 selectedSex.onNext("female")
             }
         }
+        
     }
 }
 
 //MARK: Observable
 extension SexInputView {
-    enum SexType: String {
+    enum SexButtonType: String {
         case male = "male"
         case female = "female"
     }
     
     var inputSelectedSex: Observable<String> {
         return Observable.merge(
-            maleButton.rx.tap.map { SexType.male.rawValue },
-            femaleButton.rx.tap.map { SexType.female.rawValue }
+            maleButton.rx.tap.map { SexButtonType.male.rawValue },
+            femaleButton.rx.tap.map { SexButtonType.female.rawValue }
         )
     }
     

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterProfile/RegisterProfileViewController.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterProfile/RegisterProfileViewController.swift
@@ -191,12 +191,6 @@ class RegisterProfileViewController: BaseViewController {
                 owner.presentImagePicker()
             })
             .disposed(by: disposeBag)
-        
-        sexInputView.inputSelectedSex
-            .subscribe(with: self, onNext: { owner, sex in
-                owner.sexInputView.updateButton(field: sex)
-            })
-            .disposed(by: disposeBag)
     }
 }
 

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterProfile/RegisterProfileViewController.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterProfile/RegisterProfileViewController.swift
@@ -191,6 +191,12 @@ class RegisterProfileViewController: BaseViewController {
                 owner.presentImagePicker()
             })
             .disposed(by: disposeBag)
+        
+        sexInputView.inputSelectedSex
+            .subscribe(with: self, onNext: { owner, sex in
+                owner.sexInputView.updateButton(field: sex)
+            })
+            .disposed(by: disposeBag)
     }
 }
 


### PR DESCRIPTION
## 작업 내용
**1. 취향 선택1 페이지 UI 구현하였습니다..**
![Aug-20-2024 15-01-26](https://github.com/user-attachments/assets/b4141919-7342-4b63-8395-c1418a4d778a)

**2. 커스텀 버튼을 구현하였습니다.**
➡️ didSet 프로퍼티를 이용해서 토글 버튼을 구현하였고, 중복 선택이 가능하게 하였습니다.

**3. 커스텀 프로그레스뷰를 구현하였습니다.**
➡️ 취향선택 뷰컨트롤러에서 사용할 프로그레스 바가 재사용 가능하다고 판단되어 구현하였습니다. 각 뷰컨트롤러에서는 프로그레스바를 재사용하기만 하면 됩니다. 

## 관련 이슈
#12 - [FEAT] 프로필 등록(Register) 구현
