### PR TITLE
[FEAT] 전시회 선호 장르 페이지 UI 구현

### DIFF
--- a/WooHyepHa-iOS.xcodeproj/project.pbxproj
+++ b/WooHyepHa-iOS.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		9E88DE312C74475500815EE0 /* PreferenceCultureButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE302C74475500815EE0 /* PreferenceCultureButton.swift */; };
 		9E88DE332C7466E100815EE0 /* OnboardingProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE322C7466E100815EE0 /* OnboardingProgressView.swift */; };
 		9E88DE362C75774C00815EE0 /* OnboardingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE352C75774C00815EE0 /* OnboardingButton.swift */; };
+		9E88DE382C75786000815EE0 /* RegisterPreferenceExhibitionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE372C75786000815EE0 /* RegisterPreferenceExhibitionViewController.swift */; };
 		9E9C31032C6C739800F8B01A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9E9C30FF2C6C739800F8B01A /* LaunchScreen.storyboard */; };
 		9E9C31042C6C739800F8B01A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9E9C31012C6C739800F8B01A /* Main.storyboard */; };
 /* End PBXBuildFile section */
@@ -105,6 +106,7 @@
 		9E88DE302C74475500815EE0 /* PreferenceCultureButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceCultureButton.swift; sourceTree = "<group>"; };
 		9E88DE322C7466E100815EE0 /* OnboardingProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingProgressView.swift; sourceTree = "<group>"; };
 		9E88DE352C75774C00815EE0 /* OnboardingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingButton.swift; sourceTree = "<group>"; };
+		9E88DE372C75786000815EE0 /* RegisterPreferenceExhibitionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPreferenceExhibitionViewController.swift; sourceTree = "<group>"; };
 		9E9C31002C6C739800F8B01A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		9E9C31022C6C739800F8B01A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Main.storyboard; sourceTree = "<group>"; };
 		9E9C310F2C6C77AC00F8B01A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -441,6 +443,7 @@
 		9E88DE342C7576DC00815EE0 /* RegisterPreferenceExhibition */ = {
 			isa = PBXGroup;
 			children = (
+				9E88DE372C75786000815EE0 /* RegisterPreferenceExhibitionViewController.swift */,
 			);
 			path = RegisterPreferenceExhibition;
 			sourceTree = "<group>";
@@ -591,6 +594,7 @@
 				9E0FF2AA2C6B0AD100544674 /* MatingCoordinator.swift in Sources */,
 				9E0FF29D2C6B099900544674 /* AppCoordinator.swift in Sources */,
 				9E0FF2982C6B08E300544674 /* TabBarCoordinator.swift in Sources */,
+				9E88DE382C75786000815EE0 /* RegisterPreferenceExhibitionViewController.swift in Sources */,
 				9E5906652C4F993C00647DEE /* AppDelegate.swift in Sources */,
 				9E88DDF62C6DB27500815EE0 /* RegisterProfileViewController.swift in Sources */,
 				9E88DE232C74263100815EE0 /* OnboardingHeaderView.swift in Sources */,

--- a/WooHyepHa-iOS.xcodeproj/project.pbxproj
+++ b/WooHyepHa-iOS.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		9E88DE332C7466E100815EE0 /* OnboardingProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE322C7466E100815EE0 /* OnboardingProgressView.swift */; };
 		9E88DE362C75774C00815EE0 /* OnboardingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE352C75774C00815EE0 /* OnboardingButton.swift */; };
 		9E88DE382C75786000815EE0 /* RegisterPreferenceExhibitionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE372C75786000815EE0 /* RegisterPreferenceExhibitionViewController.swift */; };
+		9E88DE3B2C75794D00815EE0 /* PreferenceExhibitionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE3A2C75794D00815EE0 /* PreferenceExhibitionView.swift */; };
 		9E9C31032C6C739800F8B01A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9E9C30FF2C6C739800F8B01A /* LaunchScreen.storyboard */; };
 		9E9C31042C6C739800F8B01A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9E9C31012C6C739800F8B01A /* Main.storyboard */; };
 /* End PBXBuildFile section */
@@ -107,6 +108,7 @@
 		9E88DE322C7466E100815EE0 /* OnboardingProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingProgressView.swift; sourceTree = "<group>"; };
 		9E88DE352C75774C00815EE0 /* OnboardingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingButton.swift; sourceTree = "<group>"; };
 		9E88DE372C75786000815EE0 /* RegisterPreferenceExhibitionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPreferenceExhibitionViewController.swift; sourceTree = "<group>"; };
+		9E88DE3A2C75794D00815EE0 /* PreferenceExhibitionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceExhibitionView.swift; sourceTree = "<group>"; };
 		9E9C31002C6C739800F8B01A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		9E9C31022C6C739800F8B01A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Main.storyboard; sourceTree = "<group>"; };
 		9E9C310F2C6C77AC00F8B01A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -443,9 +445,18 @@
 		9E88DE342C7576DC00815EE0 /* RegisterPreferenceExhibition */ = {
 			isa = PBXGroup;
 			children = (
+				9E88DE392C75793C00815EE0 /* Components */,
 				9E88DE372C75786000815EE0 /* RegisterPreferenceExhibitionViewController.swift */,
 			);
 			path = RegisterPreferenceExhibition;
+			sourceTree = "<group>";
+		};
+		9E88DE392C75793C00815EE0 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				9E88DE3A2C75794D00815EE0 /* PreferenceExhibitionView.swift */,
+			);
+			path = Components;
 			sourceTree = "<group>";
 		};
 		9E9C30FE2C6C739800F8B01A /* Base.lproj */ = {
@@ -586,6 +597,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9E88DE332C7466E100815EE0 /* OnboardingProgressView.swift in Sources */,
+				9E88DE3B2C75794D00815EE0 /* PreferenceExhibitionView.swift in Sources */,
 				9E88DE2D2C7439AE00815EE0 /* PreferenceCultureView.swift in Sources */,
 				9E0FF2B42C6B0C3500544674 /* MyPageViewController.swift in Sources */,
 				9E5906692C4F993C00647DEE /* ViewController.swift in Sources */,

--- a/WooHyepHa-iOS.xcodeproj/project.pbxproj
+++ b/WooHyepHa-iOS.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		9E88DE2D2C7439AE00815EE0 /* PreferenceCultureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE2C2C7439AE00815EE0 /* PreferenceCultureView.swift */; };
 		9E88DE312C74475500815EE0 /* PreferenceCultureButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE302C74475500815EE0 /* PreferenceCultureButton.swift */; };
 		9E88DE332C7466E100815EE0 /* OnboardingProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE322C7466E100815EE0 /* OnboardingProgressView.swift */; };
+		9E88DE362C75774C00815EE0 /* OnboardingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DE352C75774C00815EE0 /* OnboardingButton.swift */; };
 		9E9C31032C6C739800F8B01A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9E9C30FF2C6C739800F8B01A /* LaunchScreen.storyboard */; };
 		9E9C31042C6C739800F8B01A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9E9C31012C6C739800F8B01A /* Main.storyboard */; };
 /* End PBXBuildFile section */
@@ -103,6 +104,7 @@
 		9E88DE2C2C7439AE00815EE0 /* PreferenceCultureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceCultureView.swift; sourceTree = "<group>"; };
 		9E88DE302C74475500815EE0 /* PreferenceCultureButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceCultureButton.swift; sourceTree = "<group>"; };
 		9E88DE322C7466E100815EE0 /* OnboardingProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingProgressView.swift; sourceTree = "<group>"; };
+		9E88DE352C75774C00815EE0 /* OnboardingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingButton.swift; sourceTree = "<group>"; };
 		9E9C31002C6C739800F8B01A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		9E9C31022C6C739800F8B01A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Main.storyboard; sourceTree = "<group>"; };
 		9E9C310F2C6C77AC00F8B01A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -324,6 +326,7 @@
 				9E88DDF32C6DB24200815EE0 /* RegisterProfile */,
 				9E88DE112C73240D00815EE0 /* RegisterLocation */,
 				9E88DE282C74376000815EE0 /* RegisterPreferenceCulture */,
+				9E88DE342C7576DC00815EE0 /* RegisterPreferenceExhibition */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -412,6 +415,7 @@
 				9E88DE222C74263100815EE0 /* OnboardingHeaderView.swift */,
 				9E88DE262C74340500815EE0 /* OnboardingFooterView.swift */,
 				9E88DE322C7466E100815EE0 /* OnboardingProgressView.swift */,
+				9E88DE352C75774C00815EE0 /* OnboardingButton.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -432,6 +436,13 @@
 				9E88DE302C74475500815EE0 /* PreferenceCultureButton.swift */,
 			);
 			path = Components;
+			sourceTree = "<group>";
+		};
+		9E88DE342C7576DC00815EE0 /* RegisterPreferenceExhibition */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = RegisterPreferenceExhibition;
 			sourceTree = "<group>";
 		};
 		9E9C30FE2C6C739800F8B01A /* Base.lproj */ = {
@@ -596,6 +607,7 @@
 				9E88DE312C74475500815EE0 /* PreferenceCultureButton.swift in Sources */,
 				9E88DE072C6DC85600815EE0 /* BaseView.swift in Sources */,
 				9E0FF2B02C6B0B8500544674 /* ChatViewController.swift in Sources */,
+				9E88DE362C75774C00815EE0 /* OnboardingButton.swift in Sources */,
 				9E0FF1F72C5A28C500544674 /* BaseViewController.swift in Sources */,
 				9E0FF29B2C6B095600544674 /* Coordinator.swift in Sources */,
 				9E0FF2A42C6B0A2B00544674 /* HomeCoordinator.swift in Sources */,

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/Components/OnboardingButton.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/Components/OnboardingButton.swift
@@ -1,0 +1,20 @@
+//
+//  OnboardingButton.swift
+//  WooHyepHa-iOS
+//
+//  Created by 여성일 on 8/21/24.
+//
+
+import UIKit
+
+class OnboardingButton: UIButton {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/Components/OnboardingButton.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/Components/OnboardingButton.swift
@@ -8,13 +8,47 @@
 import UIKit
 
 class OnboardingButton: UIButton {
-
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
+    
+    private var title: String
+    
+    override var isSelected: Bool {
+        didSet {
+            updateAppearance()
+        }
     }
-    */
+    
+    init(title: String) {
+        self.title = title
+        super.init(frame: .zero)
+        setButton()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
 
+private extension OnboardingButton {
+    func setButton() {
+        layer.cornerRadius = 18
+        layer.borderWidth = 0
+        setTitle(title, for: .normal)
+        setTitleColor(.gray, for: .normal)
+        titleLabel?.font = .body4
+        updateAppearance()
+    }
+
+    func updateAppearance() {
+        if isSelected {
+            backgroundColor = .MainColor.withAlphaComponent(0.1)
+            layer.borderColor = UIColor.MainColor.cgColor
+            layer.borderWidth = 1
+            setTitleColor(.MainColor, for: .normal)
+        } else {
+            backgroundColor = .gray9
+            layer.borderColor = UIColor.gray9.cgColor
+            layer.borderWidth = 0
+            setTitleColor(.gray1, for: .normal)
+        }
+    }
 }

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/Coordinator/OnboardingCoordinator.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/Coordinator/OnboardingCoordinator.swift
@@ -60,5 +60,11 @@ extension OnboardingCoordinator {
         let registerPreferencCultureViewController = RegisterPreferenceCultrueViewController()
         registerPreferencCultureViewController.coordinator = self
         navigationController.pushViewController(registerPreferencCultureViewController, animated: true)
+    }    
+    
+    func goToRegisterPreferencExhibitionViewController() {
+        let registerPreferencExhibitionViewController = RegisterPreferenceExhibitionViewController()
+        registerPreferencExhibitionViewController.coordinator = self
+        navigationController.pushViewController(registerPreferencExhibitionViewController, animated: true)
     }
 }

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceCulture/RegisterPreferenceCultrueViewController.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceCulture/RegisterPreferenceCultrueViewController.swift
@@ -120,5 +120,6 @@ extension RegisterPreferenceCultrueViewController: OnboardingHeaderViewDelegate 
 extension RegisterPreferenceCultrueViewController: OnboardingFooterViewDelegate {
     func nextButtonDidTap() {
         print("testLog: nextButton Tapped")
+        coordinator?.goToRegisterPreferencExhibitionViewController()
     }
 }

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceExhibition/Components/PreferenceExhibitionView.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceExhibition/Components/PreferenceExhibitionView.swift
@@ -7,14 +7,206 @@
 
 import UIKit
 
-class PreferenceExhibitionView: UIView {
+import Then
+import SnapKit
+import RxCocoa
+import RxSwift
 
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
+class PreferenceExhibitionView: BaseView {
+
+    private let popupExpoButton = OnboardingButton(title: "팝업 전시")
+    private let photoExpoButton = OnboardingButton(title: "사진 전시")
+    private let modernArtButton = OnboardingButton(title: "현대미술")
+    private let installationArtButton = OnboardingButton(title: "설치미술")
+    private let digitalArtButton = OnboardingButton(title: "디지털 아트")
+    private let buildingExpoButton = OnboardingButton(title: "건축 전시")
+    private let decorationArtButton = OnboardingButton(title: "장식미술")
+    private let cultureExpoButton = OnboardingButton(title: "문화 전시")
+    private let scienceExpoButton = OnboardingButton(title: "과학 전시")
+    private let historyExpoButton = OnboardingButton(title: "역사 전시")
+    
+    private let horizontalStackView1 = UIStackView().then {
+        $0.axis = .horizontal
+        $0.distribution = .equalSpacing
+        $0.spacing = 8
     }
-    */
+    
+    private let horizontalStackView2 = UIStackView().then {
+        $0.axis = .horizontal
+        $0.distribution = .equalSpacing
+        $0.spacing = 8
+    }
+    
+    private let horizontalStackView3 = UIStackView().then {
+        $0.axis = .horizontal
+        $0.distribution = .equalSpacing
+        $0.spacing = 8
+    }
+        
+    private let horizontalStackView4 = UIStackView().then {
+        $0.axis = .horizontal
+        $0.distribution = .equalSpacing
+        $0.spacing = 8
+    }
 
+    private var selectedExhibition: Set<String> = []
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func setView() {
+        showTopBorder = false
+        showBottomBorder = false
+        
+        [popupExpoButton, photoExpoButton, modernArtButton].forEach {
+            horizontalStackView1.addArrangedSubview($0)
+        }
+        
+        [installationArtButton, digitalArtButton, buildingExpoButton].forEach {
+            horizontalStackView2.addArrangedSubview($0)
+        }
+                
+        [decorationArtButton, cultureExpoButton, scienceExpoButton].forEach {
+            horizontalStackView3.addArrangedSubview($0)
+        }                
+        
+        horizontalStackView4.addArrangedSubview(historyExpoButton)
+        
+        [horizontalStackView1, horizontalStackView2, horizontalStackView3, horizontalStackView4].forEach {
+            addSubview($0)
+        }
+    }
+    
+    override func setConstraints() {
+        horizontalStackView1.snp.makeConstraints {
+            $0.width.equalTo(256)
+            $0.height.equalTo(36)
+            $0.top.equalToSuperview()
+        }
+        
+        horizontalStackView2.snp.makeConstraints {
+            $0.width.equalTo(265)
+            $0.height.equalTo(36)
+            $0.top.equalTo(horizontalStackView1.snp.bottom).offset(8)
+        }
+        
+        horizontalStackView3.snp.makeConstraints {
+            $0.width.equalTo(256)
+            $0.height.equalTo(36)
+            $0.top.equalTo(horizontalStackView2.snp.bottom).offset(8)
+        }
+        
+        horizontalStackView4.snp.makeConstraints {
+            $0.width.equalTo(78)
+            $0.height.equalTo(36)
+            $0.top.equalTo(horizontalStackView3.snp.bottom).offset(8)
+        }
+        
+        [installationArtButton, decorationArtButton].forEach {
+            $0.snp.makeConstraints {
+                $0.width.equalTo(75)
+                $0.height.equalTo(36)
+            }
+        }
+        
+        [popupExpoButton, modernArtButton, historyExpoButton].forEach {
+            $0.snp.makeConstraints {
+                $0.width.equalTo(78)
+                $0.height.equalTo(36)
+            }
+        }
+        
+        [photoExpoButton, buildingExpoButton, cultureExpoButton, scienceExpoButton].forEach {
+            $0.snp.makeConstraints {
+                $0.width.equalTo(81)
+                $0.height.equalTo(36)
+            }
+        }
+        
+        digitalArtButton.snp.makeConstraints {
+            $0.width.equalTo(93)
+            $0.height.equalTo(36)
+        }
+    }
+    
+    override func bind() {
+        inputPreferenceExhibition
+            .subscribe(with: self, onNext: { owner, type in
+                owner.toggleButton(type)
+            })
+            .disposed(by: disposeBag)
+    }
+}
+
+extension PreferenceExhibitionView {
+    enum PreferenceExhibitionButtonType: String {
+        case popupExpo = "popupExpo"
+        case photoExpo = "photoExpo"
+        case modernArt = "modernArt"
+        case installationArt = "installationArt"
+        case digitalArt = "digitalArt"
+        case buildingExpo = "buildingExpo"
+        case decorationArt = "decorationArt"
+        case cultureExpo = "cultureExpo"
+        case scienceExpo = "scienceExpo"
+        case historyExpo = "historyExpo"
+    }
+    
+    var inputPreferenceExhibition: Observable<String> {
+        return Observable.merge(
+            popupExpoButton.rx.tap.map { PreferenceExhibitionButtonType.popupExpo.rawValue },
+            photoExpoButton.rx.tap.map { PreferenceExhibitionButtonType.photoExpo.rawValue },
+            modernArtButton.rx.tap.map { PreferenceExhibitionButtonType.modernArt.rawValue },
+            installationArtButton.rx.tap.map { PreferenceExhibitionButtonType.installationArt.rawValue },
+            digitalArtButton.rx.tap.map { PreferenceExhibitionButtonType.digitalArt.rawValue },
+            buildingExpoButton.rx.tap.map { PreferenceExhibitionButtonType.buildingExpo.rawValue },
+            decorationArtButton.rx.tap.map { PreferenceExhibitionButtonType.decorationArt.rawValue },
+            cultureExpoButton.rx.tap.map { PreferenceExhibitionButtonType.cultureExpo.rawValue },
+            scienceExpoButton.rx.tap.map { PreferenceExhibitionButtonType.scienceExpo.rawValue },
+            historyExpoButton.rx.tap.map { PreferenceExhibitionButtonType.historyExpo.rawValue }
+        )
+    }
+}
+
+extension PreferenceExhibitionView {
+    private func toggleButton(_ field: String) {
+        if let buttonType = PreferenceExhibitionButtonType(rawValue: field) {
+            let button: OnboardingButton
+            switch buttonType {
+            case .popupExpo:
+                button = popupExpoButton
+            case .photoExpo:
+                button = photoExpoButton
+            case .modernArt:
+                button = modernArtButton
+            case .installationArt:
+                button = installationArtButton
+            case .digitalArt:
+                button = digitalArtButton
+            case .buildingExpo:
+                button = buildingExpoButton
+            case .decorationArt:
+                button = decorationArtButton
+            case .cultureExpo:
+                button = cultureExpoButton
+            case .scienceExpo:
+                button = scienceExpoButton
+            case .historyExpo:
+                button = historyExpoButton
+            }
+            
+            button.isSelected.toggle()
+            
+            if button.isSelected {
+                selectedExhibition.insert(field)
+            } else {
+                selectedExhibition.remove(field)
+            }
+        }
+    }
 }

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceExhibition/Components/PreferenceExhibitionView.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceExhibition/Components/PreferenceExhibitionView.swift
@@ -1,0 +1,20 @@
+//
+//  PreferenceExhibitionView.swift
+//  WooHyepHa-iOS
+//
+//  Created by 여성일 on 8/21/24.
+//
+
+import UIKit
+
+class PreferenceExhibitionView: UIView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceExhibition/RegisterPreferenceExhibitionViewController.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceExhibition/RegisterPreferenceExhibitionViewController.swift
@@ -1,0 +1,29 @@
+//
+//  RegisterPreferenceExhibitionViewController.swift
+//  WooHyepHa-iOS
+//
+//  Created by 여성일 on 8/21/24.
+//
+
+import UIKit
+
+class RegisterPreferenceExhibitionViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceExhibition/RegisterPreferenceExhibitionViewController.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceExhibition/RegisterPreferenceExhibitionViewController.swift
@@ -7,23 +7,123 @@
 
 import UIKit
 
-class RegisterPreferenceExhibitionViewController: UIViewController {
+import RxCocoa
+import RxSwift
+import SnapKit
+import Then
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
+class RegisterPreferenceExhibitionViewController: BaseViewController {
 
-        // Do any additional setup after loading the view.
+    weak var coordinator: OnboardingCoordinator?
+
+    //MARK: UI Components
+    private lazy var headerView = OnboardingHeaderView().then {
+        $0.delegate = self
+        $0.backgroundColor = .white
+        $0.rightButtonTitle = "건너뛰기"
+        $0.rightButtonTitleColor = .gray4
+    }
+
+    private let progressView = OnboardingProgressView(progressValue: 0.3333)
+    
+    private let mainTitle = UILabel().then {
+        $0.text = "어떤 장르의 전시회를 선호하시나요?"
+        $0.textColor = .gray1
+        $0.font = .sub1
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    private lazy var preferenceExhibitionView = PreferenceExhibitionView()
+    
+    private let subTitle = UILabel().then {
+        $0.text = "나중에 다시 수정할 수 있어요!"
+        $0.textAlignment = .center
+        $0.textColor = .gray4
+        $0.font = .body4
     }
-    */
+    
+    private lazy var footerView = OnboardingFooterView().then {
+        $0.showBottomBorder = false
+        $0.delegate = self
+        $0.updateNextButtonState(isEnabled: true)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    // MARK: Set ViewController
+    override func setViewController() {
+        view.backgroundColor = .white
+        
+        [headerView, progressView, mainTitle, preferenceExhibitionView, subTitle, footerView].forEach {
+            view.addSubview($0)
+        }
+    }
+    
+    override func setConstraints() {
+        headerView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide)
+            $0.height.equalTo(56)
+        }
+        
+        progressView.snp.makeConstraints {
+            $0.top.equalTo(headerView.snp.bottom).offset(10)
+            $0.height.equalTo(6)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(20)
+        }
+        
+        mainTitle.snp.makeConstraints {
+            $0.top.equalTo(progressView.snp.bottom).offset(28)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(20)
+        }
+        
+        preferenceExhibitionView.snp.makeConstraints {
+            $0.top.equalTo(mainTitle.snp.bottom).offset(32)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(20)
+            $0.width.equalTo(375)
+            $0.height.equalTo(180)
+        }
+        
+        subTitle.snp.makeConstraints {
+            $0.bottom.equalTo(footerView.snp.top).offset(-18)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(20)
+        }
+        
+        footerView.snp.makeConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide)
+            $0.height.equalTo(75)
+        }
+    }
+    
+    override func bind() {
+        var selected: [String] = []
+        preferenceExhibitionView.inputPreferenceExhibition
+            .subscribe(with: self, onNext: { owner, type in
+                if let index = selected.firstIndex(of: type) {
+                    selected.remove(at: index)
+                } else {
+                    selected.append(type)
+                }
+                print(selected)
+            })
+            .disposed(by: disposeBag)
+    }
+}
 
+extension RegisterPreferenceExhibitionViewController: OnboardingHeaderViewDelegate {
+    func leftButtonDidTap() {
+        coordinator?.pop()
+    }
+    
+    func rightButtonDidTap() {
+        print("testLog: rightButton Tapped")
+    }
+}
+
+extension RegisterPreferenceExhibitionViewController: OnboardingFooterViewDelegate {
+    func nextButtonDidTap() {
+        print("testLog: nextButton Tapped")
+    }
 }


### PR DESCRIPTION
## 작업 내용
**1. 전시회 선호 장르 페이지 UI를 구현하였습니다. **
![Aug-21-2024 11-13-54](https://github.com/user-attachments/assets/d1f45b41-2dab-4bc8-a0a4-4be438cbc97c)

**2. 재사용 할 OnboardingButton을 구현하였습다.**
다른 선호 장르 페이지에서 동일한 디자인의 버튼이 재사용되어 커스텀 버튼을 구현하였습니다.

## 관련 이슈
#12 - [FEAT] 프로필 등록(Register) 구현
