### PR TITLE
[FEAT] 클래식/무용 선호 장르 선택 페이지 구현

### DIFF
--- a/WooHyepHa-iOS.xcodeproj/project.pbxproj
+++ b/WooHyepHa-iOS.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		9E66792B2C760FF000832440 /* PreferenceMusicalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E66792A2C760FF000832440 /* PreferenceMusicalView.swift */; };
 		9E66792D2C76131700832440 /* RegisterPreferenceMusicalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E66792C2C76131700832440 /* RegisterPreferenceMusicalViewController.swift */; };
 		9E6679312C761A4100832440 /* PreferenceClassicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6679302C761A4100832440 /* PreferenceClassicView.swift */; };
+		9E6679332C761CF500832440 /* RegisterPreferenceClassicViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6679322C761CF500832440 /* RegisterPreferenceClassicViewController.swift */; };
 		9E88DDF12C6DA57100815EE0 /* Extension + UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DDF02C6DA57100815EE0 /* Extension + UIView.swift */; };
 		9E88DDF62C6DB27500815EE0 /* RegisterProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DDF52C6DB27500815EE0 /* RegisterProfileViewController.swift */; };
 		9E88DDF92C6DB33D00815EE0 /* RegisterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DDF82C6DB33D00815EE0 /* RegisterViewController.swift */; };
@@ -100,6 +101,7 @@
 		9E66792A2C760FF000832440 /* PreferenceMusicalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceMusicalView.swift; sourceTree = "<group>"; };
 		9E66792C2C76131700832440 /* RegisterPreferenceMusicalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPreferenceMusicalViewController.swift; sourceTree = "<group>"; };
 		9E6679302C761A4100832440 /* PreferenceClassicView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceClassicView.swift; sourceTree = "<group>"; };
+		9E6679322C761CF500832440 /* RegisterPreferenceClassicViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPreferenceClassicViewController.swift; sourceTree = "<group>"; };
 		9E88DDF02C6DA57100815EE0 /* Extension + UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + UIView.swift"; sourceTree = "<group>"; };
 		9E88DDF52C6DB27500815EE0 /* RegisterProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterProfileViewController.swift; sourceTree = "<group>"; };
 		9E88DDF82C6DB33D00815EE0 /* RegisterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterViewController.swift; sourceTree = "<group>"; };
@@ -412,6 +414,7 @@
 			isa = PBXGroup;
 			children = (
 				9E66792F2C761A2E00832440 /* Components */,
+				9E6679322C761CF500832440 /* RegisterPreferenceClassicViewController.swift */,
 			);
 			path = RegisterPreferenceClassic;
 			sourceTree = "<group>";
@@ -668,6 +671,7 @@
 				9E0FF2AE2C6B0B4F00544674 /* MapCoordinator.swift in Sources */,
 				9E0FF1E82C5A23E500544674 /* Extension + UIColor.swift in Sources */,
 				9E66792B2C760FF000832440 /* PreferenceMusicalView.swift in Sources */,
+				9E6679332C761CF500832440 /* RegisterPreferenceClassicViewController.swift in Sources */,
 				9E0FF2AA2C6B0AD100544674 /* MatingCoordinator.swift in Sources */,
 				9E0FF29D2C6B099900544674 /* AppCoordinator.swift in Sources */,
 				9E66792D2C76131700832440 /* RegisterPreferenceMusicalViewController.swift in Sources */,

--- a/WooHyepHa-iOS.xcodeproj/project.pbxproj
+++ b/WooHyepHa-iOS.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		9E59066E2C4F993D00647DEE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9E59066D2C4F993D00647DEE /* Assets.xcassets */; };
 		9E66792B2C760FF000832440 /* PreferenceMusicalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E66792A2C760FF000832440 /* PreferenceMusicalView.swift */; };
 		9E66792D2C76131700832440 /* RegisterPreferenceMusicalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E66792C2C76131700832440 /* RegisterPreferenceMusicalViewController.swift */; };
+		9E6679312C761A4100832440 /* PreferenceClassicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6679302C761A4100832440 /* PreferenceClassicView.swift */; };
 		9E88DDF12C6DA57100815EE0 /* Extension + UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DDF02C6DA57100815EE0 /* Extension + UIView.swift */; };
 		9E88DDF62C6DB27500815EE0 /* RegisterProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DDF52C6DB27500815EE0 /* RegisterProfileViewController.swift */; };
 		9E88DDF92C6DB33D00815EE0 /* RegisterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DDF82C6DB33D00815EE0 /* RegisterViewController.swift */; };
@@ -98,6 +99,7 @@
 		9E59066D2C4F993D00647DEE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9E66792A2C760FF000832440 /* PreferenceMusicalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceMusicalView.swift; sourceTree = "<group>"; };
 		9E66792C2C76131700832440 /* RegisterPreferenceMusicalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPreferenceMusicalViewController.swift; sourceTree = "<group>"; };
+		9E6679302C761A4100832440 /* PreferenceClassicView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceClassicView.swift; sourceTree = "<group>"; };
 		9E88DDF02C6DA57100815EE0 /* Extension + UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + UIView.swift"; sourceTree = "<group>"; };
 		9E88DDF52C6DB27500815EE0 /* RegisterProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterProfileViewController.swift; sourceTree = "<group>"; };
 		9E88DDF82C6DB33D00815EE0 /* RegisterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterViewController.swift; sourceTree = "<group>"; };
@@ -341,6 +343,7 @@
 				9E88DE342C7576DC00815EE0 /* RegisterPreferenceExhibition */,
 				9E88DE3C2C75DD4B00815EE0 /* RegisterPreferenceConcert */,
 				9E6679282C760FBB00832440 /* RegisterPreferenceMusical */,
+				9E66792E2C761A1300832440 /* RegisterPreferenceClassic */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -401,6 +404,22 @@
 			isa = PBXGroup;
 			children = (
 				9E66792A2C760FF000832440 /* PreferenceMusicalView.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		9E66792E2C761A1300832440 /* RegisterPreferenceClassic */ = {
+			isa = PBXGroup;
+			children = (
+				9E66792F2C761A2E00832440 /* Components */,
+			);
+			path = RegisterPreferenceClassic;
+			sourceTree = "<group>";
+		};
+		9E66792F2C761A2E00832440 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				9E6679302C761A4100832440 /* PreferenceClassicView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -644,6 +663,7 @@
 				9E88DE3B2C75794D00815EE0 /* PreferenceExhibitionView.swift in Sources */,
 				9E88DE2D2C7439AE00815EE0 /* PreferenceCultureView.swift in Sources */,
 				9E0FF2B42C6B0C3500544674 /* MyPageViewController.swift in Sources */,
+				9E6679312C761A4100832440 /* PreferenceClassicView.swift in Sources */,
 				9E5906692C4F993C00647DEE /* ViewController.swift in Sources */,
 				9E0FF2AE2C6B0B4F00544674 /* MapCoordinator.swift in Sources */,
 				9E0FF1E82C5A23E500544674 /* Extension + UIColor.swift in Sources */,

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/Coordinator/OnboardingCoordinator.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/Coordinator/OnboardingCoordinator.swift
@@ -78,5 +78,11 @@ extension OnboardingCoordinator {
         let registerPreferenceMusicalViewController = RegisterPreferenceMusicalViewController()
         registerPreferenceMusicalViewController.coordinator = self
         navigationController.pushViewController(registerPreferenceMusicalViewController, animated: true)
+    }    
+    
+    func goToRegisterPreferenceClassicViewController() {
+        let registerPreferenceClassicViewController = RegisterPreferenceClassicViewController()
+        registerPreferenceClassicViewController.coordinator = self
+        navigationController.pushViewController(registerPreferenceClassicViewController, animated: true)
     }
 }

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceClassic/Components/PreferenceClassicView.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceClassic/Components/PreferenceClassicView.swift
@@ -7,14 +7,188 @@
 
 import UIKit
 
-class PreferenceClassicView: UIView {
+import Then
+import SnapKit
+import RxCocoa
+import RxSwift
 
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
+class PreferenceClassicView: BaseView {
+    
+    private let orchestraButton = OnboardingButton(title: "오케스트라")
+    private let chamberMusicButton = OnboardingButton(title: "실내악")
+    private let soloButton = OnboardingButton(title: "독주")
+    private let operaButton = OnboardingButton(title: "오페라")
+    private let symphonyButton = OnboardingButton(title: "교향곡")
+    private let sonataButton = OnboardingButton(title: "소나타")
+    private let concertoButton = OnboardingButton(title: "협주곡")
+    private let balletButton = OnboardingButton(title: "발레")
+    private let modernDanceButton = OnboardingButton(title: "현대무용")
+    private let traditionalDanceButton = OnboardingButton(title: "전통무용")
+    private let lineDanceButton = OnboardingButton(title: "라인댄스")
+    private let tapDanceButton = OnboardingButton(title: "탭댄스")
+    
+    private let horizontalStackView1 = UIStackView().then {
+        $0.axis = .horizontal
+        $0.distribution = .fillEqually
+        $0.spacing = 11
     }
-    */
+    
+    private let horizontalStackView2 = UIStackView().then {
+        $0.axis = .horizontal
+        $0.distribution = .fillEqually
+        $0.spacing = 11
+    }
+    
+    private let horizontalStackView3 = UIStackView().then {
+        $0.axis = .horizontal
+        $0.distribution = .fillEqually
+        $0.spacing = 11
+    }
+    
+    private let horizontalStackView4 = UIStackView().then {
+        $0.axis = .horizontal
+        $0.distribution = .fillEqually
+        $0.spacing = 11
+    }
+    
+    private let verticalStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.distribution = .fillEqually
+        $0.spacing = 20
+    }
+    
+    private var selectedExhibition: Set<String> = []
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func setView() {
+        showTopBorder = false
+        showBottomBorder = false
+        
+        [orchestraButton, chamberMusicButton, soloButton].forEach {
+            horizontalStackView1.addArrangedSubview($0)
+        }
+        
+        [operaButton, symphonyButton, sonataButton].forEach {
+            horizontalStackView2.addArrangedSubview($0)
+        }
+        
+        [concertoButton, balletButton, modernDanceButton].forEach {
+            horizontalStackView3.addArrangedSubview($0)
+        }
+        
+        [traditionalDanceButton, lineDanceButton, tapDanceButton].forEach {
+            horizontalStackView4.addArrangedSubview($0)
+        }
+        
+        [horizontalStackView1, horizontalStackView2, horizontalStackView3, horizontalStackView4].forEach {
+            verticalStackView.addArrangedSubview($0)
+        }
+        
+        addSubview(verticalStackView)
+    }
+    
+    override func setConstraints() {
+        verticalStackView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.width.equalToSuperview()
+            $0.height.equalToSuperview()
+        }
+        
+        [orchestraButton, chamberMusicButton, soloButton, operaButton, symphonyButton, sonataButton, concertoButton, balletButton, modernDanceButton, traditionalDanceButton, lineDanceButton, tapDanceButton].forEach {
+            $0.snp.makeConstraints {
+                $0.height.equalTo(48)
+            }
+        }
+    }
+    
+    override func bind() {
+        inputPreferenceClassic
+            .subscribe(with: self, onNext: { owner, type in
+                owner.toggleButton(type)
+            })
+            .disposed(by: disposeBag)
+    }
+}
 
+extension PreferenceClassicView {
+    enum PreferenceClassicButtonType: String {
+        case orchestra = "orchestra"
+        case chamberMusic = "chamberMusic"
+        case solo = "solo"
+        case opera = "opera"
+        case symphony = "symphony"
+        case sonata = "sonata"
+        case concerto = "experimentDrama"
+        case ballet = "ballet"
+        case modernDance = "modernDance"
+        case traditionalDance = "traditionalDance"
+        case lineDance = "lineDance"
+        case tapDance = "tapDance"
+    }
+    
+    var inputPreferenceClassic: Observable<String> {
+        return Observable.merge(
+            orchestraButton.rx.tap.map { PreferenceClassicButtonType.orchestra.rawValue },
+            chamberMusicButton.rx.tap.map { PreferenceClassicButtonType.chamberMusic.rawValue },
+            soloButton.rx.tap.map { PreferenceClassicButtonType.solo.rawValue },
+            operaButton.rx.tap.map { PreferenceClassicButtonType.opera.rawValue },
+            symphonyButton.rx.tap.map { PreferenceClassicButtonType.symphony.rawValue },
+            sonataButton.rx.tap.map { PreferenceClassicButtonType.sonata.rawValue },
+            concertoButton.rx.tap.map { PreferenceClassicButtonType.concerto.rawValue },
+            balletButton.rx.tap.map { PreferenceClassicButtonType.ballet.rawValue },
+            modernDanceButton.rx.tap.map { PreferenceClassicButtonType.modernDance.rawValue },
+            traditionalDanceButton.rx.tap.map { PreferenceClassicButtonType.traditionalDance.rawValue },
+            lineDanceButton.rx.tap.map { PreferenceClassicButtonType.lineDance.rawValue },
+            tapDanceButton.rx.tap.map { PreferenceClassicButtonType.tapDance.rawValue }
+        )
+    }
+}
+
+extension PreferenceClassicView {
+    private func toggleButton(_ field: String) {
+        if let buttonType = PreferenceClassicButtonType(rawValue: field) {
+            let button: OnboardingButton
+            switch buttonType {
+            case .orchestra:
+                button = orchestraButton
+            case .chamberMusic:
+                button = chamberMusicButton
+            case .solo:
+                button = soloButton
+            case .opera:
+                button = operaButton
+            case .symphony:
+                button = symphonyButton
+            case .sonata:
+                button = sonataButton
+            case .concerto:
+                button = concertoButton
+            case .ballet:
+                button = balletButton
+            case .modernDance:
+                button = modernDanceButton
+            case .traditionalDance:
+                button = traditionalDanceButton
+            case .lineDance:
+                button = lineDanceButton            
+            case .tapDance:
+                button = tapDanceButton
+            }
+            
+            button.isSelected.toggle()
+            
+            if button.isSelected {
+                selectedExhibition.insert(field)
+            } else {
+                selectedExhibition.remove(field)
+            }
+        }
+    }
 }

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceClassic/Components/PreferenceClassicView.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceClassic/Components/PreferenceClassicView.swift
@@ -1,0 +1,20 @@
+//
+//  PreferenceClassicView.swift
+//  WooHyepHa-iOS
+//
+//  Created by 여성일 on 8/21/24.
+//
+
+import UIKit
+
+class PreferenceClassicView: UIView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceClassic/RegisterPreferenceClassicViewController.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceClassic/RegisterPreferenceClassicViewController.swift
@@ -1,0 +1,29 @@
+//
+//  RegisterPreferenceClassicViewController.swift
+//  WooHyepHa-iOS
+//
+//  Created by 여성일 on 8/21/24.
+//
+
+import UIKit
+
+class RegisterPreferenceClassicViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceClassic/RegisterPreferenceClassicViewController.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceClassic/RegisterPreferenceClassicViewController.swift
@@ -7,23 +7,123 @@
 
 import UIKit
 
-class RegisterPreferenceClassicViewController: UIViewController {
+import RxCocoa
+import RxSwift
+import SnapKit
+import Then
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
+class RegisterPreferenceClassicViewController: BaseViewController {
 
-        // Do any additional setup after loading the view.
+    weak var coordinator: OnboardingCoordinator?
+
+    //MARK: UI Components
+    private lazy var headerView = OnboardingHeaderView().then {
+        $0.delegate = self
+        $0.backgroundColor = .white
+        $0.rightButtonTitle = "건너뛰기"
+        $0.rightButtonTitleColor = .gray4
+    }
+
+    private let progressView = OnboardingProgressView(progressValue: 0.8333)
+    
+    private let mainTitle = UILabel().then {
+        $0.text = "어떤 장르의 클래식/무용을 선호하시나요?"
+        $0.textColor = .gray1
+        $0.font = .sub1
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    private lazy var preferenceClassicView = PreferenceClassicView()
+    
+    private let subTitle = UILabel().then {
+        $0.text = "나중에 다시 수정할 수 있어요!"
+        $0.textAlignment = .center
+        $0.textColor = .gray4
+        $0.font = .body4
     }
-    */
+    
+    private lazy var footerView = OnboardingFooterView().then {
+        $0.showBottomBorder = false
+        $0.delegate = self
+        $0.updateNextButtonState(isEnabled: true)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    // MARK: Set ViewController
+    override func setViewController() {
+        view.backgroundColor = .white
+        
+        [headerView, progressView, mainTitle, preferenceClassicView, subTitle, footerView].forEach {
+            view.addSubview($0)
+        }
+    }
+    
+    override func setConstraints() {
+        headerView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide)
+            $0.height.equalTo(56)
+        }
+        
+        progressView.snp.makeConstraints {
+            $0.top.equalTo(headerView.snp.bottom).offset(10)
+            $0.height.equalTo(6)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(20)
+        }
+        
+        mainTitle.snp.makeConstraints {
+            $0.top.equalTo(progressView.snp.bottom).offset(28)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(20)
+        }
+        
+        preferenceClassicView.snp.makeConstraints {
+            $0.top.equalTo(mainTitle.snp.bottom).offset(32)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(20)
+            $0.height.equalTo(252)
+        }
+        
+        subTitle.snp.makeConstraints {
+            $0.bottom.equalTo(footerView.snp.top).offset(-18)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(20)
+        }
+        
+        footerView.snp.makeConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide)
+            $0.height.equalTo(75)
+        }
+    }
+    
+    override func bind() {
+        var selected: [String] = []
+        preferenceClassicView.inputPreferenceClassic
+            .subscribe(with: self, onNext: { owner, type in
+                if let index = selected.firstIndex(of: type) {
+                    selected.remove(at: index)
+                } else {
+                    selected.append(type)
+                }
+                print(selected)
+            })
+            .disposed(by: disposeBag)
+    }
+}
 
+extension RegisterPreferenceClassicViewController: OnboardingHeaderViewDelegate {
+    func leftButtonDidTap() {
+        coordinator?.pop()
+    }
+    
+    func rightButtonDidTap() {
+        print("testLog: rightButton Tapped")
+    }
+}
+
+extension RegisterPreferenceClassicViewController: OnboardingFooterViewDelegate {
+    func nextButtonDidTap() {
+        print("testLog: nextButton Tapped")
+        coordinator?.goToRegisterPreferenceConcertViewController()
+    }
 }

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceMusical/RegisterPreferenceMusicalViewController.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceMusical/RegisterPreferenceMusicalViewController.swift
@@ -124,6 +124,6 @@ extension RegisterPreferenceMusicalViewController: OnboardingHeaderViewDelegate 
 extension RegisterPreferenceMusicalViewController: OnboardingFooterViewDelegate {
     func nextButtonDidTap() {
         print("testLog: nextButton Tapped")
-        coordinator?.goToRegisterPreferenceConcertViewController()
+        coordinator?.goToRegisterPreferenceClassicViewController()
     }
 }


### PR DESCRIPTION
## 작업 내용
**1. 래식/무용 선호 장르 페이지 UI를 구현하였습니다. **
![Aug-21-2024 22-06-32](https://github.com/user-attachments/assets/f53e695d-580d-480b-a2c3-d0357b8838d2)


## 관련 이슈
#12 - [FEAT] 프로필 등록(Register) 구현
