### PR TITLE
[FEAT] 관람목적 선택 페이지 구현

### DIFF
--- a/WooHyepHa-iOS.xcodeproj/project.pbxproj
+++ b/WooHyepHa-iOS.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		9E6679312C761A4100832440 /* PreferenceClassicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6679302C761A4100832440 /* PreferenceClassicView.swift */; };
 		9E6679332C761CF500832440 /* RegisterPreferenceClassicViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6679322C761CF500832440 /* RegisterPreferenceClassicViewController.swift */; };
 		9E6679372C761F4500832440 /* SelectPurposeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6679362C761F4500832440 /* SelectPurposeView.swift */; };
+		9E6679392C7620F300832440 /* RegisterSelectPurposeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6679382C7620F300832440 /* RegisterSelectPurposeViewController.swift */; };
 		9E88DDF12C6DA57100815EE0 /* Extension + UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DDF02C6DA57100815EE0 /* Extension + UIView.swift */; };
 		9E88DDF62C6DB27500815EE0 /* RegisterProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DDF52C6DB27500815EE0 /* RegisterProfileViewController.swift */; };
 		9E88DDF92C6DB33D00815EE0 /* RegisterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DDF82C6DB33D00815EE0 /* RegisterViewController.swift */; };
@@ -104,6 +105,7 @@
 		9E6679302C761A4100832440 /* PreferenceClassicView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceClassicView.swift; sourceTree = "<group>"; };
 		9E6679322C761CF500832440 /* RegisterPreferenceClassicViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPreferenceClassicViewController.swift; sourceTree = "<group>"; };
 		9E6679362C761F4500832440 /* SelectPurposeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectPurposeView.swift; sourceTree = "<group>"; };
+		9E6679382C7620F300832440 /* RegisterSelectPurposeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterSelectPurposeViewController.swift; sourceTree = "<group>"; };
 		9E88DDF02C6DA57100815EE0 /* Extension + UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + UIView.swift"; sourceTree = "<group>"; };
 		9E88DDF52C6DB27500815EE0 /* RegisterProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterProfileViewController.swift; sourceTree = "<group>"; };
 		9E88DDF82C6DB33D00815EE0 /* RegisterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterViewController.swift; sourceTree = "<group>"; };
@@ -434,6 +436,7 @@
 			isa = PBXGroup;
 			children = (
 				9E6679352C761F2E00832440 /* Components */,
+				9E6679382C7620F300832440 /* RegisterSelectPurposeViewController.swift */,
 			);
 			path = RegisterSelectPurpose;
 			sourceTree = "<group>";
@@ -723,6 +726,7 @@
 				9E88DDF92C6DB33D00815EE0 /* RegisterViewController.swift in Sources */,
 				9E0FF2B62C6B0C5100544674 /* MyPageCoordinator.swift in Sources */,
 				9E0FF2AC2C6B0B2800544674 /* MapViewController.swift in Sources */,
+				9E6679392C7620F300832440 /* RegisterSelectPurposeViewController.swift in Sources */,
 				9E0FF2A62C6B0A5F00544674 /* HomeViewController.swift in Sources */,
 				9E88DE132C73243600815EE0 /* RegisterLocationViewController.swift in Sources */,
 				9E88DE272C74340500815EE0 /* OnboardingFooterView.swift in Sources */,

--- a/WooHyepHa-iOS.xcodeproj/project.pbxproj
+++ b/WooHyepHa-iOS.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		9E66792D2C76131700832440 /* RegisterPreferenceMusicalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E66792C2C76131700832440 /* RegisterPreferenceMusicalViewController.swift */; };
 		9E6679312C761A4100832440 /* PreferenceClassicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6679302C761A4100832440 /* PreferenceClassicView.swift */; };
 		9E6679332C761CF500832440 /* RegisterPreferenceClassicViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6679322C761CF500832440 /* RegisterPreferenceClassicViewController.swift */; };
+		9E6679372C761F4500832440 /* SelectPurposeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6679362C761F4500832440 /* SelectPurposeView.swift */; };
 		9E88DDF12C6DA57100815EE0 /* Extension + UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DDF02C6DA57100815EE0 /* Extension + UIView.swift */; };
 		9E88DDF62C6DB27500815EE0 /* RegisterProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DDF52C6DB27500815EE0 /* RegisterProfileViewController.swift */; };
 		9E88DDF92C6DB33D00815EE0 /* RegisterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E88DDF82C6DB33D00815EE0 /* RegisterViewController.swift */; };
@@ -102,6 +103,7 @@
 		9E66792C2C76131700832440 /* RegisterPreferenceMusicalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPreferenceMusicalViewController.swift; sourceTree = "<group>"; };
 		9E6679302C761A4100832440 /* PreferenceClassicView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceClassicView.swift; sourceTree = "<group>"; };
 		9E6679322C761CF500832440 /* RegisterPreferenceClassicViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPreferenceClassicViewController.swift; sourceTree = "<group>"; };
+		9E6679362C761F4500832440 /* SelectPurposeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectPurposeView.swift; sourceTree = "<group>"; };
 		9E88DDF02C6DA57100815EE0 /* Extension + UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + UIView.swift"; sourceTree = "<group>"; };
 		9E88DDF52C6DB27500815EE0 /* RegisterProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterProfileViewController.swift; sourceTree = "<group>"; };
 		9E88DDF82C6DB33D00815EE0 /* RegisterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterViewController.swift; sourceTree = "<group>"; };
@@ -346,6 +348,7 @@
 				9E88DE3C2C75DD4B00815EE0 /* RegisterPreferenceConcert */,
 				9E6679282C760FBB00832440 /* RegisterPreferenceMusical */,
 				9E66792E2C761A1300832440 /* RegisterPreferenceClassic */,
+				9E6679342C761F0300832440 /* RegisterSelectPurpose */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -423,6 +426,22 @@
 			isa = PBXGroup;
 			children = (
 				9E6679302C761A4100832440 /* PreferenceClassicView.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		9E6679342C761F0300832440 /* RegisterSelectPurpose */ = {
+			isa = PBXGroup;
+			children = (
+				9E6679352C761F2E00832440 /* Components */,
+			);
+			path = RegisterSelectPurpose;
+			sourceTree = "<group>";
+		};
+		9E6679352C761F2E00832440 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				9E6679362C761F4500832440 /* SelectPurposeView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -689,6 +708,7 @@
 				9E88DDF12C6DA57100815EE0 /* Extension + UIView.swift in Sources */,
 				9E5906672C4F993C00647DEE /* SceneDelegate.swift in Sources */,
 				9E0FF2B92C6C4F5A00544674 /* SplashViewController.swift in Sources */,
+				9E6679372C761F4500832440 /* SelectPurposeView.swift in Sources */,
 				9E88DE0A2C6DD58B00815EE0 /* BirthInputView.swift in Sources */,
 				9E0FF2962C6B066200544674 /* TabBarItemType.swift in Sources */,
 				9E88DE312C74475500815EE0 /* PreferenceCultureButton.swift in Sources */,

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/Components/OnboardingFooterView.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/Components/OnboardingFooterView.swift
@@ -20,6 +20,12 @@ class OnboardingFooterView: BaseView {
 
     weak var delegate: OnboardingFooterViewDelegate?
     
+    var nextButtonTitle: String = "" {
+        didSet {
+            nextButton.setTitle(nextButtonTitle, for: .normal)
+        }
+    }
+    
     // MARK: UI Components
     private let nextButton = UIButton().then {
         $0.setTitle("다음", for: .normal)

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/Coordinator/OnboardingCoordinator.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/Coordinator/OnboardingCoordinator.swift
@@ -84,5 +84,11 @@ extension OnboardingCoordinator {
         let registerPreferenceClassicViewController = RegisterPreferenceClassicViewController()
         registerPreferenceClassicViewController.coordinator = self
         navigationController.pushViewController(registerPreferenceClassicViewController, animated: true)
+    }    
+    
+    func goToRegisterSelectPurposeViewController() {
+        let registerSelectPurposeViewController = RegisterSelectPurposeViewController()
+        registerSelectPurposeViewController.coordinator = self
+        navigationController.pushViewController(registerSelectPurposeViewController, animated: true)
     }
 }

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceClassic/RegisterPreferenceClassicViewController.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterPreferenceClassic/RegisterPreferenceClassicViewController.swift
@@ -124,6 +124,6 @@ extension RegisterPreferenceClassicViewController: OnboardingHeaderViewDelegate 
 extension RegisterPreferenceClassicViewController: OnboardingFooterViewDelegate {
     func nextButtonDidTap() {
         print("testLog: nextButton Tapped")
-        coordinator?.goToRegisterPreferenceConcertViewController()
+        coordinator?.goToRegisterSelectPurposeViewController()
     }
 }

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterSelectPurpose/Components/SelectPurposeView.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterSelectPurpose/Components/SelectPurposeView.swift
@@ -7,14 +7,110 @@
 
 import UIKit
 
-class SelectPurposeView: UIView {
+import Then
+import SnapKit
+import RxCocoa
+import RxSwift
 
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
+class SelectPurposeView: BaseView {
+    private var currentlySelectedButton: OnboardingButton?
+    
+    private let learnButton = OnboardingButton(title: "지식습득")
+    private let healingButton = OnboardingButton(title: "휴식 및 힐링")
+    private let socialActivitiesButton = OnboardingButton(title: "사회적 활동")
+    private let inspirationButton = OnboardingButton(title: "영감 및 창의성")
+    private let etcButton = OnboardingButton(title: "기타")
+    
+    private let verticalStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.distribution = .fillEqually
+        $0.spacing = 18
     }
-    */
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func setView() {
+        showTopBorder = false
+        showBottomBorder = false
+        
+        [learnButton, healingButton, socialActivitiesButton, inspirationButton, etcButton].forEach {
+            verticalStackView.addArrangedSubview($0)
+        }
+        
+        addSubview(verticalStackView)
+    }
+    
+    override func setConstraints() {
+        verticalStackView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.width.equalToSuperview()
+            $0.height.equalToSuperview()
+        }
+        
+        [learnButton, healingButton, socialActivitiesButton, inspirationButton, etcButton].forEach {
+            $0.snp.makeConstraints {
+                $0.height.equalTo(48)
+            }
+        }
+    }
+    
+    override func bind() {
+        inputSelectPurpose
+            .subscribe(with: self, onNext: { owner, type in
+                owner.toggleButton(type)
+            })
+            .disposed(by: disposeBag)
+    }
+}
 
+extension SelectPurposeView {
+    enum SelectPurposeButtonType: String {
+        case learn = "learn"
+        case healing = "healing"
+        case socialActivities = "socialActivities"
+        case inspiration = "inspiration"
+        case etc = "etc"
+    }
+    
+    var inputSelectPurpose: Observable<String> {
+        return Observable.merge(
+            learnButton.rx.tap.map { SelectPurposeButtonType.learn.rawValue },
+            healingButton.rx.tap.map { SelectPurposeButtonType.healing.rawValue },
+            socialActivitiesButton.rx.tap.map { SelectPurposeButtonType.socialActivities.rawValue },
+            inspirationButton.rx.tap.map { SelectPurposeButtonType.inspiration.rawValue },
+            etcButton.rx.tap.map { SelectPurposeButtonType.etc.rawValue }
+        )
+    }
+}
+
+extension SelectPurposeView {
+    private func toggleButton(_ field: String) {
+        if let buttonType = SelectPurposeButtonType(rawValue: field) {
+            let button: OnboardingButton
+            switch buttonType {
+            case .learn:
+                button = learnButton
+            case .healing:
+                button = healingButton
+            case .socialActivities:
+                button = socialActivitiesButton
+            case .inspiration:
+                button = inspirationButton
+            case .etc:
+                button = etcButton
+            }
+            
+            if button != currentlySelectedButton {
+                currentlySelectedButton?.isSelected = false
+                button.isSelected = true
+                currentlySelectedButton = button
+            }
+        }
+    }
 }

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterSelectPurpose/Components/SelectPurposeView.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterSelectPurpose/Components/SelectPurposeView.swift
@@ -1,0 +1,20 @@
+//
+//  SelectPurposeView.swift
+//  WooHyepHa-iOS
+//
+//  Created by 여성일 on 8/21/24.
+//
+
+import UIKit
+
+class SelectPurposeView: UIView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterSelectPurpose/RegisterSelectPurposeViewController.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterSelectPurpose/RegisterSelectPurposeViewController.swift
@@ -1,0 +1,29 @@
+//
+//  RegisterSelectPurposeViewController.swift
+//  WooHyepHa-iOS
+//
+//  Created by 여성일 on 8/21/24.
+//
+
+import UIKit
+
+class RegisterSelectPurposeViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterSelectPurpose/RegisterSelectPurposeViewController.swift
+++ b/WooHyepHa-iOS/Sources/Presentation/Onboarding/RegisterSelectPurpose/RegisterSelectPurposeViewController.swift
@@ -7,23 +7,119 @@
 
 import UIKit
 
-class RegisterSelectPurposeViewController: UIViewController {
+import RxCocoa
+import RxSwift
+import SnapKit
+import Then
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
+class RegisterSelectPurposeViewController: BaseViewController {
 
-        // Do any additional setup after loading the view.
+    weak var coordinator: OnboardingCoordinator?
+
+    //MARK: UI Components
+    private lazy var headerView = OnboardingHeaderView().then {
+        $0.delegate = self
+        $0.backgroundColor = .white
+        $0.rightButtonTitle = "건너뛰기"
+        $0.rightButtonTitleColor = .gray4
+    }
+
+    private let progressView = OnboardingProgressView(progressValue: 1.0)
+    
+    private let mainTitle = UILabel().then {
+        let attributedString = NSMutableAttributedString(string: "문화예술을 관람하는\n", attributes: [.font: UIFont.sub1, .foregroundColor: UIColor.gray1])
+        attributedString.append(NSAttributedString(string: "주요 목적은 무엇인가요? (택1)", attributes: [.font: UIFont.sub1, .foregroundColor: UIColor.gray1]))
+        $0.attributedText = attributedString
+        $0.numberOfLines = 2
+        $0.textAlignment = .left
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    private lazy var selectPurpseView = SelectPurposeView()
+    
+    private let subTitle = UILabel().then {
+        $0.text = "나중에 다시 수정할 수 있어요!"
+        $0.textAlignment = .center
+        $0.textColor = .gray4
+        $0.font = .body4
     }
-    */
+    
+    private lazy var footerView = OnboardingFooterView().then {
+        $0.showBottomBorder = false
+        $0.delegate = self
+        $0.updateNextButtonState(isEnabled: true)
+        $0.nextButtonTitle = "입장하기"
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    // MARK: Set ViewController
+    override func setViewController() {
+        view.backgroundColor = .white
+        
+        [headerView, progressView, mainTitle, selectPurpseView, subTitle, footerView].forEach {
+            view.addSubview($0)
+        }
+    }
+    
+    override func setConstraints() {
+        headerView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide)
+            $0.height.equalTo(56)
+        }
+        
+        progressView.snp.makeConstraints {
+            $0.top.equalTo(headerView.snp.bottom).offset(10)
+            $0.height.equalTo(6)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(20)
+        }
+        
+        mainTitle.snp.makeConstraints {
+            $0.top.equalTo(progressView.snp.bottom).offset(28)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(20)
+        }
+        
+        selectPurpseView.snp.makeConstraints {
+            $0.top.equalTo(mainTitle.snp.bottom).offset(32)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(20)
+            $0.height.equalTo(312)
+        }
+        
+        subTitle.snp.makeConstraints {
+            $0.bottom.equalTo(footerView.snp.top).offset(-18)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(20)
+        }
+        
+        footerView.snp.makeConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide)
+            $0.height.equalTo(75)
+        }
+    }
+    
+    override func bind() {
+        selectPurpseView.inputSelectPurpose
+            .subscribe(with: self, onNext: { owner, type in
+                print(type)
+            })
+            .disposed(by: disposeBag)
+    }
+}
 
+extension RegisterSelectPurposeViewController: OnboardingHeaderViewDelegate {
+    func leftButtonDidTap() {
+        coordinator?.pop()
+    }
+    
+    func rightButtonDidTap() {
+        print("testLog: rightButton Tapped")
+    }
+}
+
+extension RegisterSelectPurposeViewController: OnboardingFooterViewDelegate {
+    func nextButtonDidTap() {
+        print("testLog: nextButton Tapped")
+    }
 }


### PR DESCRIPTION
## 작업 내용
**1. 관람목적 선택 페이지 UI를 구현하였습니다. **
![Aug-21-2024 22-37-33](https://github.com/user-attachments/assets/f08f9e09-8670-4870-9eaa-77eb24ae1753)

**2. 재사용 푸터뷰에 nextButton의 타이틀을 지정하는 속성을 추가하였습니다.**
마지막 페이지(관람목적 선택 페이지)의 nextButton은 "다음"이 아닌 "입장하기"로 디자인 되었기 때문에, 따로 지정할 속성을 추가하여 기본 값은 "다음"으로 설정하고 변경이 필요하면 개발자가 변경하도록 구현하였습니다.

## 관련 이슈
#12 - [FEAT] 프로필 등록(Register) 구현
